### PR TITLE
Upgrade solution from .NET 7 to .NET 10

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Run the application (serves both API and Blazor WASM client)
+cd TimeTracker.API && dotnet run
+
+# Build the solution
+dotnet build TimeTracker.sln
+
+# EF Core migrations (run from TimeTracker.API)
+cd TimeTracker.API
+dotnet ef migrations add <MigrationName> --context TimeTrackerDataContext
+dotnet ef migrations add <MigrationName> --context IdentityDataContext
+dotnet ef database update --context TimeTrackerDataContext
+dotnet ef database update --context IdentityDataContext
+
+# Set user secrets (required for local dev DB credentials)
+cd TimeTracker.API
+dotnet user-secrets set "DbUser" "<username>"
+dotnet user-secrets set "DbPassword" "<password>"
+```
+
+The app runs at `https://localhost:7006` (https) or `http://localhost:5019` (http). Swagger UI is available at `/swagger`.
+
+## Architecture
+
+This is a .NET 7 solution with three projects:
+
+- **`TimeTracker.API`** — ASP.NET Core web host. Serves the REST API and hosts the Blazor WebAssembly client via `UseBlazorFrameworkFiles()`. All HTTP traffic goes through this single process.
+- **`TimeTracker.Client`** — Blazor WebAssembly SPA. Calls the API using a relative `HttpClient` (no CORS needed since it's hosted by the same process). Uses Radzen.Blazor for charts and Tailwind CSS for styling.
+- **`TimeTracker.Shared`** — Class library shared between API and Client. Contains EF entities (`Entities/`) and request/response DTOs (`Models/`).
+
+### Data layer
+
+Two separate EF Core `DbContext`s both targeting the same SQL Server database (`TimeTrackerDb`):
+- `TimeTrackerDataContext` — app schema (`app`): `TimeEntries`, `Projects`, `ProjectDetails`, `ProjectUsers`
+- `IdentityDataContext` — identity schema (`id`): ASP.NET Identity tables
+
+`Project` uses soft-delete (`SoftDeleteableEntity`). `TimeEntry` stores a `UserId` string (ASP.NET Identity user ID) rather than a navigation property to avoid cascade delete issues.
+
+Mapster handles entity↔DTO mapping. The one non-trivial mapping is `Project → ProjectResponse`, which flattens `ProjectDetails` fields, configured in `Program.cs::ConfigureMapster()`.
+
+### API layer
+
+Controllers → Services → Repositories pattern. `IUserContextService` extracts the current user's ID from `HttpContext` claims and is injected into services to scope queries per user.
+
+- `TimeEntryController` — requires `[Authorize]` (any authenticated user)
+- `ProjectController` — requires `[Authorize(Roles = "Admin")]`
+- `LoginController` / `AccountController` — public endpoints for JWT auth and registration
+
+### Authentication
+
+JWT Bearer authentication. On login, the API issues a JWT containing the username, user ID, and roles. The Blazor client stores the token in `localStorage` via `Blazored.LocalStorage`. `AuthStateProvider` reads the token on each navigation, parses claims from the JWT payload, and sets `HttpClient.DefaultRequestHeaders.Authorization`.
+
+In development, DB credentials (`DbUser`, `DbPassword`) are injected via [.NET User Secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets) and merged into the connection string at startup.

--- a/TimeTracker.API/Program.cs
+++ b/TimeTracker.API/Program.cs
@@ -3,8 +3,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Data.SqlClient;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.OpenApi.Models;
-using Swashbuckle.AspNetCore.Filters;
+using Scalar.AspNetCore;
 using TimeTracker.API.Data;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -12,26 +11,12 @@ var builder = WebApplication.CreateBuilder(args);
 var timeTrackerConnection = GetConnectionString(builder, "TimeTrackerConnection", "DbUser", "DbPassword");
 var identityConnection = GetConnectionString(builder, "IdentityConnection", "DbUser", "DbPassword");
 
-// Add services to the container.
-
 builder.Services.AddControllersWithViews();
 builder.Services.AddRazorPages();
 
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen(options =>
-{
-    options.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme {
-        In = ParameterLocation.Header,
-        Name = "Authorization",
-        Type = SecuritySchemeType.ApiKey
-    });
-
-    options.OperationFilter<SecurityRequirementsOperationFilter>();
-});
+builder.Services.AddOpenApi();
 builder.Services.AddDbContext<TimeTrackerDataContext>(options => options.UseSqlServer(timeTrackerConnection));
 builder.Services.AddDbContext<IdentityDataContext>(options => options.UseSqlServer(identityConnection));
-
 
 builder.Services.AddIdentity<User, IdentityRole>(options =>
     {
@@ -73,11 +58,10 @@ builder.Services.AddScoped<IUserContextService, UserContextService>();
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment() || app.Environment.IsProduction())
+if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
+    app.MapOpenApi();
+    app.MapScalarApiReference();
     app.UseWebAssemblyDebugging();
 }
 
@@ -113,7 +97,6 @@ static string? GetConnectionString(WebApplicationBuilder builder,
                                   string passwordCfgName)
 {
     var connectionString = builder.Configuration.GetConnectionString(connectionCfgName);
-    // Build Connection String
     if (builder.Environment.IsDevelopment()) {
         var conStrBuilder = new SqlConnectionStringBuilder(connectionString)
         {

--- a/TimeTracker.API/Repositories/ProjectRepository.cs
+++ b/TimeTracker.API/Repositories/ProjectRepository.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Internal;
 using TimeTracker.API.Data;
 
 namespace TimeTracker.API.Repositories;

--- a/TimeTracker.API/TimeTracker.API.csproj
+++ b/TimeTracker.API/TimeTracker.API.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>4848edd4-bb25-4512-b84a-bf96dbbf8df5</UserSecretsId>
@@ -10,21 +10,19 @@
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'https' " />
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'http' " />
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="Mapster" Version="7.3.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.8">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.5.3" />
+    <PackageReference Include="Mapster" Version="7.4.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TimeTracker.Client/AuthStateProvider.cs
+++ b/TimeTracker.Client/AuthStateProvider.cs
@@ -3,10 +3,6 @@ using System.Security.Claims;
 using System.Text.Json;
 using Blazored.LocalStorage;
 using Microsoft.AspNetCore.Components.Authorization;
-using Microsoft.AspNetCore.Identity;
-using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.VisualBasic;
-
 namespace TimeTracker.Client;
 
 public class AuthStateProvider : AuthenticationStateProvider

--- a/TimeTracker.Client/Pages/Projects.razor
+++ b/TimeTracker.Client/Pages/Projects.razor
@@ -33,7 +33,7 @@
     </TemplateColumn>
 </QuickGrid>
 
-<Paginator Value="@paginator" />
+<Paginator State="@paginator" />
 
 @code {
 

--- a/TimeTracker.Client/Pages/TimeEntries.razor
+++ b/TimeTracker.Client/Pages/TimeEntries.razor
@@ -36,7 +36,7 @@
         </button>
     </TemplateColumn>
 </QuickGrid>
-<Paginator Value="@paginator" />
+<Paginator State="@paginator" />
 
 <div class="flex justify-content-between items-end">
     <MyButton AddMarginTop Text="Create Time Entry" OnClick="CreateTimeEntry" />

--- a/TimeTracker.Client/TimeTracker.Client.csproj
+++ b/TimeTracker.Client/TimeTracker.Client.csproj
@@ -1,20 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazored.LocalStorage" Version="4.3.0" />
-    <PackageReference Include="Blazored.Toast" Version="4.1.0" />
-    <PackageReference Include="Mapster" Version="7.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="7.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="0.1.0-alpha.22351.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.5" PrivateAssets="all" />
-    <PackageReference Include="Radzen.Blazor" Version="4.15.9" />
+    <PackageReference Include="Blazored.LocalStorage" Version="4.4.0" />
+    <PackageReference Include="Blazored.Toast" Version="4.2.1" />
+    <PackageReference Include="Mapster" Version="7.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" PrivateAssets="all" />
+    <PackageReference Include="Radzen.Blazor" Version="5.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TimeTracker.Shared/TimeTracker.Shared.csproj
+++ b/TimeTracker.Shared/TimeTracker.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -17,6 +17,6 @@
     <Folder Include="Models\TimeEntry\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.8" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Upgrades all three projects (API, Client, Shared) from `net7.0` to `net10.0`
- Replaces Swashbuckle with .NET 10 native OpenAPI + Scalar UI (available at `/scalar/v1` in dev only)
- Updates all Microsoft.AspNetCore.* and EF Core packages to `10.0.8`
- Fixes Paginator API breaking change: `Value` → `State` parameter (QuickGrid alpha → stable)
- Removes obsolete `Microsoft.AspNetCore.Authentication` 2.2.0 package
- Removes unused imports in AuthStateProvider and ProjectRepository

## Fixes
Closes #18
Closes #11 (Swagger/debugging no longer runs in production — Scalar is dev-only by design)

## Test plan
- [ ] `dotnet build TimeTracker.sln` — 0 errors
- [ ] `dotnet run --project TimeTracker.API` — app starts on https://localhost:7006
- [ ] Navigate to `/scalar/v1` — Scalar API UI loads in dev
- [ ] Log in, navigate to Time Entries — QuickGrid renders and paginates correctly
- [ ] Switch to Year filter — Radzen chart renders

## Notes
- `System.Linq.Dynamic.Core` 1.3.7 high severity vulnerability flagged as a build warning — tracked in #19, transitive dependency from Radzen.Blazor and cannot be resolved until Radzen ships an update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)