### PR TITLE
feat: nav rail polish and drawer footer matching mockup

### DIFF
--- a/TimeTracker.Web/Features/Auth/AppUserClaimsPrincipalFactory.cs
+++ b/TimeTracker.Web/Features/Auth/AppUserClaimsPrincipalFactory.cs
@@ -1,0 +1,18 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using TimeTracker.Shared.Entities;
+
+namespace TimeTracker.Web.Features.Auth;
+
+public class AppUserClaimsPrincipalFactory(UserManager<User> userManager, IOptions<IdentityOptions> optionsAccessor)
+    : UserClaimsPrincipalFactory<User>(userManager, optionsAccessor)
+{
+    protected override async Task<ClaimsIdentity> GenerateClaimsAsync(User user)
+    {
+        var identity = await base.GenerateClaimsAsync(user);
+        if (!string.IsNullOrEmpty(user.Email))
+            identity.AddClaim(new Claim(ClaimTypes.Email, user.Email));
+        return identity;
+    }
+}

--- a/TimeTracker.Web/Program.cs
+++ b/TimeTracker.Web/Program.cs
@@ -43,7 +43,8 @@ builder.Services.AddIdentity<User, IdentityRole>(options =>
         options.SignIn.RequireConfirmedEmail = false;
     })
     .AddEntityFrameworkStores<IdentityDataContext>()
-    .AddDefaultTokenProviders();
+    .AddDefaultTokenProviders()
+    .AddClaimsPrincipalFactory<AppUserClaimsPrincipalFactory>();
 
 builder.Services.ConfigureApplicationCookie(options =>
 {

--- a/TimeTracker.Web/Shared/Layout/MainLayout.razor
+++ b/TimeTracker.Web/Shared/Layout/MainLayout.razor
@@ -28,31 +28,35 @@
             <div style="padding:14px 16px; border-bottom:1px solid var(--mud-palette-divider); display:flex; align-items:center; gap:10px">
                 <img src="/images/dzk-icon.png" alt="DZK"
                      style="width:40px; height:40px; border-radius:8px; object-fit:contain;" />
-                <MudText Typo="Typo.subtitle1" Style="font-weight:500; color:var(--mud-palette-secondary)">TimeTracker</MudText>
+                <div style="display:flex; flex-direction:column; line-height:1.15">
+                    <MudText Typo="Typo.subtitle1" Style="font-weight:700; color:var(--mud-palette-secondary); line-height:1.15">TimeTracker</MudText>
+                    <MudText Typo="Typo.caption" Style="line-height:1.15; color:var(--mud-palette-text-secondary)">DZK Consulting</MudText>
+                </div>
             </div>
             <div style="flex:1; overflow-y:auto">
                 <NavMenu OnNavClick="() => drawerOpen = false" />
             </div>
-            <div style="border-top:1px solid var(--mud-palette-divider); padding:12px 16px">
+            <div style="border-top:1px solid var(--mud-palette-divider); padding:8px 12px">
                 <AuthorizeView>
                     <Authorized>
-                        <div style="display:flex; align-items:center; gap:10px; margin-bottom:8px">
+                        <div style="display:flex; align-items:center; gap:12px; padding:4px 6px">
                             <MudAvatar Style="background:var(--mud-palette-secondary); color:#fff; font-weight:500; font-size:.9rem; width:36px; height:36px; flex-shrink:0">
                                 @GetInitials(context.User.Identity?.Name)
                             </MudAvatar>
-                            <MudText Typo="Typo.body2" Style="overflow:hidden; text-overflow:ellipsis; white-space:nowrap">
-                                @context.User.Identity?.Name
-                            </MudText>
+                            <div style="flex:1; min-width:0; display:flex; flex-direction:column; gap:1px">
+                                <span style="font-size:.875rem; font-weight:500; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; line-height:1.3">
+                                    @GetDisplayName(context.User.Identity?.Name)
+                                </span>
+                                <span style="font-size:.75rem; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; line-height:1.3; color:var(--mud-palette-text-secondary)">
+                                    @(context.User.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value ?? context.User.Identity?.Name)
+                                </span>
+                            </div>
+                            <form method="post" action="/auth/logout" style="flex-shrink:0">
+                                <AntiforgeryToken />
+                                <MudIconButton ButtonType="ButtonType.Submit" Icon="@Icons.Material.Filled.Logout"
+                                               Color="Color.Default" title="Sign out" Size="Size.Small" />
+                            </form>
                         </div>
-                        <form method="post" action="/auth/logout">
-                            <AntiforgeryToken />
-                            <MudButton ButtonType="ButtonType.Submit" FullWidth="true"
-                                       Variant="Variant.Text" Color="Color.Default"
-                                       StartIcon="@Icons.Material.Filled.Logout"
-                                       Style="justify-content:flex-start; text-transform:none">
-                                Logout
-                            </MudButton>
-                        </form>
                     </Authorized>
                 </AuthorizeView>
             </div>
@@ -107,6 +111,15 @@
     public void Dispose()
     {
         Nav.LocationChanged -= OnLocationChanged;
+    }
+
+    private static string GetDisplayName(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return "Unknown";
+        if (!name.Contains('@')) return name;
+        var local = name.Split('@')[0];
+        var parts = local.Split(['.', '_', '-'], StringSplitOptions.RemoveEmptyEntries);
+        return string.Join(" ", parts.Select(p => char.ToUpper(p[0]) + p[1..]));
     }
 
     private static string GetInitials(string? name)

--- a/TimeTracker.Web/wwwroot/css/app.css
+++ b/TimeTracker.Web/wwwroot/css/app.css
@@ -174,11 +174,27 @@ html, body, #app {
     background: var(--mud-palette-primary);
 }
 
-/* ── MudNavMenu — active link matches mockup (primary tint bg, primary text) ── */
+/* ── MudNavMenu — nav link styles matching mockup ── */
+.mud-nav-link {
+    border-radius: 6px !important;
+    margin: 2px 8px !important;
+    font-weight: 600 !important;
+    min-height: 46px;
+}
+
+.mud-nav-link:hover {
+    background: rgba(0,0,0,0.06) !important;
+    border-radius: 6px !important;
+}
+
 .mud-nav-link.active {
     background: rgba(0,104,205,0.10) !important;
     color: var(--mud-palette-primary) !important;
-    border-radius: 6px;
+    border-radius: 6px !important;
+}
+
+.mud-nav-link.active .mud-icon-root {
+    color: var(--mud-palette-primary) !important;
 }
 
 /* ── Entry sheet — bottom sheet ── */


### PR DESCRIPTION
## Summary

- **Nav links**: rounded hover box, taller height (46px), semi-bold (600) font weight, inset margin, active icon colour matches primary text
- **Drawer brand**: added "DZK Consulting" caption beneath the TimeTracker heading
- **Drawer footer**: replaced stacked avatar+name / full-width logout button with the mockup's row layout — avatar | name + email column | logout icon button on the right
- **Email claim**: added `AppUserClaimsPrincipalFactory` so `ClaimTypes.Email` is baked into the auth cookie at sign-in, enabling the footer to show the real email address rather than the username

## Test plan

- [ ] Log out and back in to pick up the new email claim
- [ ] Drawer footer shows display name on top line and email address on caption line
- [ ] "DZK Consulting" appears beneath TimeTracker in the brand header
- [ ] Nav links have rounded hover background and taller hit area
- [ ] Active nav link icon matches the primary blue text colour
- [ ] All 71 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)