### PR TITLE
security: address all 8 findings from pre-Phase 7 sweep

### DIFF
--- a/TimeTracker.Tests/Features/Auth/ExternalLoginServiceTests.cs
+++ b/TimeTracker.Tests/Features/Auth/ExternalLoginServiceTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using TimeTracker.Web.Features.Auth;
 using TimeTracker.Tests.Infrastructure;
@@ -19,20 +20,28 @@ public class ExternalLoginServiceTests
 
     // Helper that wires everything from the fixture
     private static (ExternalLoginService Service, IdentityFixture Fixture) Build(
-        params string[] allowedEmails)
+        string[] allowedEmails,
+        string? adminEmail = null)
     {
-        var configEntries = allowedEmails
-            .Select((email, i) => ($"Authentication:AllowedEmails:{i}", email))
-            .ToArray();
+        var configPairs = allowedEmails
+            .Select((e, i) => new KeyValuePair<string, string?>($"Authentication:AllowedEmails:{i}", e))
+            .ToList();
 
-        var fixture = new IdentityFixture(configEntries);
+        if (adminEmail is not null)
+            configPairs.Add(new KeyValuePair<string, string?>("Authentication:AdminEmail", adminEmail));
+
+        var fixture = new IdentityFixture(allowedEmails
+            .Select((e, i) => ($"Authentication:AllowedEmails:{i}", e)).ToArray());
+
         var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(allowedEmails
-                .Select((e, i) => new KeyValuePair<string, string?>($"Authentication:AllowedEmails:{i}", e)))
+            .AddInMemoryCollection(configPairs)
             .Build();
 
         return (new ExternalLoginService(fixture.UserManager, config), fixture);
     }
+
+    private static (ExternalLoginService Service, IdentityFixture Fixture) Build(
+        params string[] allowedEmails) => Build(allowedEmails, adminEmail: null);
 
     [Fact]
     public async Task Returns_EmailNotAllowed_when_email_not_in_config()
@@ -149,6 +158,88 @@ public class ExternalLoginServiceTests
             Assert.Equal(2, logins.Count);
             Assert.Contains(logins, l => l.LoginProvider == "Google");
             Assert.Contains(logins, l => l.LoginProvider == "Entra");
+        }
+    }
+
+    [Fact]
+    public async Task Assigns_Admin_role_when_email_matches_AdminEmail()
+    {
+        var (svc, fixture) = Build([AllowedEmail], adminEmail: AllowedEmail);
+        using (fixture)
+        {
+            await fixture.RoleManager.CreateAsync(new IdentityRole("Admin"));
+
+            await svc.FindOrCreateUserAsync(AllowedEmail, Provider, ProviderKey);
+
+            var user = await fixture.UserManager.FindByEmailAsync(AllowedEmail);
+            var isAdmin = await fixture.UserManager.IsInRoleAsync(user!, "Admin");
+            Assert.True(isAdmin);
+        }
+    }
+
+    [Fact]
+    public async Task Does_not_assign_Admin_role_when_email_does_not_match_AdminEmail()
+    {
+        var otherEmail = "other@example.com";
+        var (svc, fixture) = Build([AllowedEmail, otherEmail], adminEmail: AllowedEmail);
+        using (fixture)
+        {
+            await fixture.RoleManager.CreateAsync(new IdentityRole("Admin"));
+
+            await svc.FindOrCreateUserAsync(otherEmail, Provider, ProviderKey);
+
+            var user = await fixture.UserManager.FindByEmailAsync(otherEmail);
+            var isAdmin = await fixture.UserManager.IsInRoleAsync(user!, "Admin");
+            Assert.False(isAdmin);
+        }
+    }
+
+    [Fact]
+    public async Task Admin_role_assignment_is_case_insensitive()
+    {
+        var (svc, fixture) = Build([AllowedEmail], adminEmail: AllowedEmail.ToUpper());
+        using (fixture)
+        {
+            await fixture.RoleManager.CreateAsync(new IdentityRole("Admin"));
+
+            await svc.FindOrCreateUserAsync(AllowedEmail, Provider, ProviderKey);
+
+            var user = await fixture.UserManager.FindByEmailAsync(AllowedEmail);
+            var isAdmin = await fixture.UserManager.IsInRoleAsync(user!, "Admin");
+            Assert.True(isAdmin);
+        }
+    }
+
+    [Fact]
+    public async Task Admin_role_assignment_is_idempotent()
+    {
+        var (svc, fixture) = Build([AllowedEmail], adminEmail: AllowedEmail);
+        using (fixture)
+        {
+            await fixture.RoleManager.CreateAsync(new IdentityRole("Admin"));
+
+            await svc.FindOrCreateUserAsync(AllowedEmail, Provider, ProviderKey);
+            await svc.FindOrCreateUserAsync(AllowedEmail, Provider, ProviderKey);
+
+            var user = await fixture.UserManager.FindByEmailAsync(AllowedEmail);
+            var roles = await fixture.UserManager.GetRolesAsync(user!);
+            Assert.Single(roles);
+        }
+    }
+
+    [Fact]
+    public async Task Does_not_assign_Admin_role_when_AdminEmail_not_configured()
+    {
+        var (svc, fixture) = Build([AllowedEmail]);
+        using (fixture)
+        {
+            await fixture.RoleManager.CreateAsync(new IdentityRole("Admin"));
+
+            await svc.FindOrCreateUserAsync(AllowedEmail, Provider, ProviderKey);
+
+            var user = await fixture.UserManager.FindByEmailAsync(AllowedEmail);
+            var isAdmin = await fixture.UserManager.IsInRoleAsync(user!, "Admin");
+            Assert.False(isAdmin);
         }
     }
 }

--- a/TimeTracker.Tests/Infrastructure/IdentityFixture.cs
+++ b/TimeTracker.Tests/Infrastructure/IdentityFixture.cs
@@ -13,6 +13,7 @@ public sealed class IdentityFixture : IDisposable
     private readonly ServiceProvider _provider;
 
     public UserManager<User> UserManager => _provider.GetRequiredService<UserManager<User>>();
+    public RoleManager<IdentityRole> RoleManager => _provider.GetRequiredService<RoleManager<IdentityRole>>();
 
     public IdentityFixture(params (string Key, string Value)[] configEntries)
     {

--- a/TimeTracker.Web/Dev/Pages/DevToolsPage.razor
+++ b/TimeTracker.Web/Dev/Pages/DevToolsPage.razor
@@ -1,0 +1,43 @@
+@page "/dev"
+@rendermode InteractiveServer
+@attribute [Authorize(Roles = "Admin")]
+@using TimeTracker.Web.Dev
+@using TimeTracker.Shared.Entities
+@using Microsoft.AspNetCore.Identity
+@inject IDbContextFactory<TimeTrackerDataContext> CtxFactory
+@inject UserManager<User> UserManager
+@inject ISnackbar Snackbar
+
+<PageTitle>Dev Tools</PageTitle>
+
+<MudText Typo="Typo.h5" Class="mb-4">Dev Tools</MudText>
+
+<MudStack Row="true" Spacing="2">
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Seed" Disabled="_busy">Seed</MudButton>
+    <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="Clear" Disabled="_busy">Clear All</MudButton>
+</MudStack>
+
+@code {
+    private bool _busy;
+
+    private async Task Seed()
+    {
+        _busy = true;
+        var message = await DevDataSeeder.SeedAsync(CtxFactory, UserManager);
+        Snackbar.Add(message, Severity.Success);
+        _busy = false;
+    }
+
+    private async Task Clear()
+    {
+        _busy = true;
+        await using var ctx = await CtxFactory.CreateDbContextAsync();
+        ctx.TimeEntries.RemoveRange(ctx.TimeEntries);
+        ctx.ProjectUsers.RemoveRange(ctx.ProjectUsers);
+        ctx.Projects.RemoveRange(ctx.Projects);
+        ctx.Clients.RemoveRange(ctx.Clients);
+        await ctx.SaveChangesAsync();
+        Snackbar.Add("Cleared all data.", Severity.Warning);
+        _busy = false;
+    }
+}

--- a/TimeTracker.Web/Features/Auth/AppUserClaimsPrincipalFactory.cs
+++ b/TimeTracker.Web/Features/Auth/AppUserClaimsPrincipalFactory.cs
@@ -5,8 +5,11 @@ using TimeTracker.Shared.Entities;
 
 namespace TimeTracker.Web.Features.Auth;
 
-public class AppUserClaimsPrincipalFactory(UserManager<User> userManager, IOptions<IdentityOptions> optionsAccessor)
-    : UserClaimsPrincipalFactory<User>(userManager, optionsAccessor)
+public class AppUserClaimsPrincipalFactory(
+    UserManager<User> userManager,
+    RoleManager<IdentityRole> roleManager,
+    IOptions<IdentityOptions> optionsAccessor)
+    : UserClaimsPrincipalFactory<User, IdentityRole>(userManager, roleManager, optionsAccessor)
 {
     protected override async Task<ClaimsIdentity> GenerateClaimsAsync(User user)
     {

--- a/TimeTracker.Web/Features/Auth/AuthEndpoints.cs
+++ b/TimeTracker.Web/Features/Auth/AuthEndpoints.cs
@@ -37,7 +37,8 @@ public static class AuthEndpoints
                 return Results.Redirect($"/login?error={result.Status.ToString().ToLowerInvariant().Replace("_", "-")}");
 
             await signInManager.SignInAsync(result.User!, isPersistent: true);
-            return Results.Redirect(returnUrl ?? "/timeentries");
+            var safeReturnUrl = Uri.TryCreate(returnUrl, UriKind.Relative, out _) ? returnUrl! : "/timeentries";
+            return Results.LocalRedirect(safeReturnUrl);
         });
 
         app.MapPost("/auth/logout", async (SignInManager<User> signInManager) =>

--- a/TimeTracker.Web/Features/Auth/ExternalLoginService.cs
+++ b/TimeTracker.Web/Features/Auth/ExternalLoginService.cs
@@ -20,6 +20,14 @@ public class ExternalLoginService(UserManager<User> userManager, IConfiguration 
                 return new ExternalLoginResult(ExternalLoginStatus.CreateUserFailed);
         }
 
+        var adminEmail = configuration["Authentication:AdminEmail"];
+        if (!string.IsNullOrEmpty(adminEmail) &&
+            string.Equals(email, adminEmail, StringComparison.OrdinalIgnoreCase) &&
+            !await userManager.IsInRoleAsync(user, "Admin"))
+        {
+            await userManager.AddToRoleAsync(user, "Admin");
+        }
+
         var existingLogins = await userManager.GetLoginsAsync(user);
         if (!existingLogins.Any(l => l.LoginProvider == loginProvider && l.ProviderKey == providerKey))
         {

--- a/TimeTracker.Web/Features/Clients/ClientEndpoints.cs
+++ b/TimeTracker.Web/Features/Clients/ClientEndpoints.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using TimeTracker.Shared.Exceptions;
 
 namespace TimeTracker.Web.Features.Clients;
@@ -7,6 +8,8 @@ public static class ClientEndpoints
     public static void MapClientEndpoints(this WebApplication app)
     {
         var group = app.MapGroup("/api/clients").RequireAuthorization();
+        var adminGroup = app.MapGroup("/api/clients").RequireAuthorization(
+            new AuthorizationPolicyBuilder().RequireAuthenticatedUser().RequireRole("Admin").Build());
 
         group.MapGet("/", async (IClientService service, bool includeArchived = false) =>
             Results.Ok(await service.GetAllClients(includeArchived)));
@@ -17,31 +20,31 @@ public static class ClientEndpoints
             return client is null ? Results.NotFound() : Results.Ok(client);
         });
 
-        group.MapPost("/", async (ClientCreateRequest request, IClientService service) =>
+        adminGroup.MapPost("/", async (ClientCreateRequest request, IClientService service) =>
         {
             await service.CreateClient(request);
             return Results.Created();
         });
 
-        group.MapPut("/{id:int}", async (int id, ClientUpdateRequest request, IClientService service) =>
+        adminGroup.MapPut("/{id:int}", async (int id, ClientUpdateRequest request, IClientService service) =>
         {
             try { await service.UpdateClient(id, request); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }
         });
 
-        group.MapPost("/{id:int}/archive", async (int id, IClientService service) =>
+        adminGroup.MapPost("/{id:int}/archive", async (int id, IClientService service) =>
         {
             try { await service.ArchiveClient(id); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }
         });
 
-        group.MapPost("/{id:int}/unarchive", async (int id, IClientService service) =>
+        adminGroup.MapPost("/{id:int}/unarchive", async (int id, IClientService service) =>
         {
             try { await service.UnarchiveClient(id); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }
         });
 
-        group.MapDelete("/{id:int}", async (int id, IClientService service) =>
+        adminGroup.MapDelete("/{id:int}", async (int id, IClientService service) =>
         {
             try { await service.DeleteClient(id); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }

--- a/TimeTracker.Web/Features/Projects/ProjectEndpoints.cs
+++ b/TimeTracker.Web/Features/Projects/ProjectEndpoints.cs
@@ -1,3 +1,5 @@
+using TimeTracker.Shared.Exceptions;
+
 namespace TimeTracker.Web.Features.Projects;
 
 public static class ProjectEndpoints
@@ -23,14 +25,14 @@ public static class ProjectEndpoints
 
         group.MapPut("/{id:int}", async (int id, ProjectUpdateRequest request, IProjectService svc) =>
         {
-            await svc.UpdateProject(id, request);
-            return Results.NoContent();
+            try { await svc.UpdateProject(id, request); return Results.NoContent(); }
+            catch (EntityNotFoundException) { return Results.NotFound(); }
         });
 
         group.MapDelete("/{id:int}", async (int id, IProjectService svc) =>
         {
-            await svc.DeleteProject(id);
-            return Results.NoContent();
+            try { await svc.DeleteProject(id); return Results.NoContent(); }
+            catch (EntityNotFoundException) { return Results.NotFound(); }
         });
     }
 }

--- a/TimeTracker.Web/Features/TimeEntries/TimeEntryEndpoints.cs
+++ b/TimeTracker.Web/Features/TimeEntries/TimeEntryEndpoints.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Mvc;
+using TimeTracker.Shared.Exceptions;
 
 namespace TimeTracker.Web.Features.TimeEntries;
 
@@ -37,14 +37,14 @@ public static class TimeEntryEndpoints
 
         group.MapPut("/{id:int}", async (int id, TimeEntryUpdateRequest request, ITimeEntryService svc) =>
         {
-            await svc.UpdateTimeEntry(id, request);
-            return Results.NoContent();
+            try { await svc.UpdateTimeEntry(id, request); return Results.NoContent(); }
+            catch (EntityNotFoundException) { return Results.NotFound(); }
         });
 
         group.MapDelete("/{id:int}", async (int id, ITimeEntryService svc) =>
         {
-            await svc.DeleteTimeEntry(id);
-            return Results.NoContent();
+            try { await svc.DeleteTimeEntry(id); return Results.NoContent(); }
+            catch (EntityNotFoundException) { return Results.NotFound(); }
         });
     }
 }

--- a/TimeTracker.Web/Features/TimeEntries/TimeEntryModels.cs
+++ b/TimeTracker.Web/Features/TimeEntries/TimeEntryModels.cs
@@ -31,7 +31,6 @@ public class TimeEntryCreateRequest
     public DateTime Start { get; set; }
     public DateTime? End { get; set; }
     public string? Note { get; set; }
-    public string UserId { get; set; } = string.Empty;
 }
 
 public class TimeEntryUpdateRequest

--- a/TimeTracker.Web/Program.cs
+++ b/TimeTracker.Web/Program.cs
@@ -3,6 +3,7 @@ using MudBlazor.Services;
 using TimeTracker.Web;
 using Mapster;
 using Microsoft.AspNetCore.Authentication.Google;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Data.SqlClient;
 using Scalar.AspNetCore;
@@ -75,10 +76,22 @@ var app = builder.Build();
 
 TypeAdapterConfig.GlobalSettings.Scan(Assembly.GetExecutingAssembly());
 
+using (var scope = app.Services.CreateScope())
+{
+    var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+    if (!await roleManager.RoleExistsAsync("Admin"))
+        await roleManager.CreateAsync(new IdentityRole("Admin"));
+}
+
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
     app.MapScalarApiReference();
+
+    var adminPolicy = new AuthorizationPolicyBuilder()
+        .RequireAuthenticatedUser()
+        .RequireRole("Admin")
+        .Build();
 
     app.MapPost("/api/dev/seed", async (
         IDbContextFactory<TimeTrackerDataContext> ctxFactory,
@@ -86,7 +99,7 @@ if (app.Environment.IsDevelopment())
     {
         var result = await DevDataSeeder.SeedAsync(ctxFactory, userManager);
         return Results.Ok(result);
-    }).AllowAnonymous();
+    }).RequireAuthorization(adminPolicy);
 
     app.MapPost("/api/dev/clear", async (
         IDbContextFactory<TimeTrackerDataContext> ctxFactory) =>
@@ -98,7 +111,7 @@ if (app.Environment.IsDevelopment())
         ctx.Clients.RemoveRange(ctx.Clients);
         await ctx.SaveChangesAsync();
         return Results.Ok("Cleared all time entries, projects and clients.");
-    }).AllowAnonymous();
+    }).RequireAuthorization(adminPolicy);
 }
 
 app.UseHttpsRedirection();
@@ -116,6 +129,10 @@ app.MapTimeEntryEndpoints();
 app.MapProjectEndpoints();
 app.MapClientEndpoints();
 app.MapAuthEndpoints();
+
+var allowedEmails = app.Configuration.GetSection("Authentication:AllowedEmails").Get<string[]>();
+if (allowedEmails is null || allowedEmails.Length == 0)
+    throw new InvalidOperationException("Authentication:AllowedEmails must be configured with at least one entry.");
 
 app.Run();
 

--- a/TimeTracker.Web/Shared/Layout/NavMenu.razor
+++ b/TimeTracker.Web/Shared/Layout/NavMenu.razor
@@ -1,4 +1,5 @@
 @inject NavigationManager Nav
+@inject IWebHostEnvironment Env
 
 <MudNavMenu>
     <MudNavLink Href="/" Match="NavLinkMatch.All"
@@ -19,6 +20,14 @@
         <MudNavLink Href="/clients"
                     Icon="@Icons.Material.Filled.Business">Clients</MudNavLink>
     </AuthorizeView>
+
+    @if (Env.IsDevelopment())
+    {
+        <AuthorizeView Roles="Admin">
+            <MudNavLink Href="/dev"
+                        Icon="@Icons.Material.Filled.DeveloperMode">Dev Tools</MudNavLink>
+        </AuthorizeView>
+    }
 </MudNavMenu>
 
 @code {

--- a/TimeTracker.Web/appsettings.json
+++ b/TimeTracker.Web/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ConnectionStrings": {
-    "TimeTrackerConnection": "Server=localhost;Database=TimeTrackerDb;TrustServerCertificate=true",
-    "IdentityConnection": "Server=localhost;Database=TimeTrackerDb;TrustServerCertificate=true"
+    "TimeTrackerConnection": "Server=localhost;Database=TimeTrackerDb;Encrypt=True",
+    "IdentityConnection": "Server=localhost;Database=TimeTrackerDb;Encrypt=True"
   },
   "Logging": {
     "LogLevel": {
@@ -9,10 +9,6 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*",
-  "JwtSecurityKey" : "my top secret key",
-  "JwtIssuer": "https://localhost",
-  "JwtAudience": "https://localhost",
-  "JwtExpiryInDays" : 1
+  "AllowedHosts": "*"
 }
 


### PR DESCRIPTION
## Summary

Addresses all findings from the pre-Phase 7 security review.

| # | Finding | Fix |
|---|---------|-----|
| 1 | Client mutation endpoints had no role restriction | POST/PUT/DELETE/archive require `Admin` role |
| 2 | JWT secret hardcoded in `appsettings.json` | Removed all `Jwt*` keys |
| 3 | Open redirect in `/auth/callback` | `Results.LocalRedirect` with relative URL validation |
| 4 | No startup assertion for `AllowedEmails` | App throws on startup if not configured |
| 5 | `UserId` on `TimeEntryCreateRequest` DTO | Removed — service always uses claims |
| 6 | `TrustServerCertificate=true` in base config | Replaced with `Encrypt=True`; dev config retains it |
| 7 | Dev endpoints were anonymous | Require `Admin` role; new `/dev` DevTools page added |
| 8 | `EntityNotFoundException` returned 500 on PUT/DELETE | Now returns 404 (matching `ClientEndpoints` pattern) |

## New config required

Add to user secrets (dev) and Azure App Service config (prod):
- `Authentication:AdminEmail` — email that receives Admin role on first login

## Test plan
- [ ] Build passes, all 71 tests green
- [ ] Log in with Google as the `AdminEmail` — verify Admin role assigned
- [ ] `/dev` page visible in nav, Seed and Clear buttons work
- [ ] Non-admin user cannot call client mutation API endpoints
- [ ] Missing `AllowedEmails` config causes startup failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)