### PR TITLE
perf: push pagination to DB and run queries concurrently (closes #13, #17)

### DIFF
--- a/TimeTracker.Tests/Features/TimeEntries/TimeEntryServiceTests.cs
+++ b/TimeTracker.Tests/Features/TimeEntries/TimeEntryServiceTests.cs
@@ -510,4 +510,25 @@ public class TimeEntryServiceTests
         var result = await CreateService(options).GetTimeEntries(0, 10);
         Assert.Equal(TimeSpan.FromHours(2.5), result.TotalDuration);
     }
+
+    [Fact]
+    public async Task TotalDuration_ReflectsAllEntries_NotJustCurrentPage()
+    {
+        var options = CreateOptions();
+        using var seed = new TimeTrackerDataContext(options);
+        var project = MakeProject(UserId);
+        seed.Projects.Add(project);
+        await seed.SaveChangesAsync();
+        seed.TimeEntries.AddRange(
+            new TimeEntry { ProjectId = project.Id, UserId = UserId, Start = new DateTime(2024, 1, 1, 9, 0, 0), End = new DateTime(2024, 1, 1, 11, 0, 0) },
+            new TimeEntry { ProjectId = project.Id, UserId = UserId, Start = new DateTime(2024, 1, 2, 9, 0, 0), End = new DateTime(2024, 1, 2, 10, 0, 0) },
+            new TimeEntry { ProjectId = project.Id, UserId = UserId, Start = new DateTime(2024, 1, 3, 9, 0, 0), End = new DateTime(2024, 1, 3, 10, 30, 0) });
+        await seed.SaveChangesAsync();
+
+        // Request only the first page (1 entry) — TotalDuration must still sum all 3
+        var result = await CreateService(options).GetTimeEntries(skip: 0, limit: 1);
+        Assert.Single(result.TimeEntries);
+        Assert.Equal(3, result.Count);
+        Assert.Equal(TimeSpan.FromHours(4.5), result.TotalDuration);
+    }
 }

--- a/TimeTracker.Web/Features/TimeEntries/TimeEntryService.cs
+++ b/TimeTracker.Web/Features/TimeEntries/TimeEntryService.cs
@@ -27,9 +27,6 @@ public class TimeEntryService : ITimeEntryService
 
             .Where(te => te.UserId == userId && !te.Project.IsDeleted);
 
-    private static TimeSpan CalculateTotalDuration(IEnumerable<TimeEntry> entries) =>
-        entries.Where(e => e.End.HasValue)
-               .Aggregate(TimeSpan.Zero, (acc, e) => acc + (e.End!.Value - e.Start));
 
     public async Task<TimeEntryResponse?> GetTimeEntryById(int id)
     {
@@ -92,37 +89,32 @@ public class TimeEntryService : ITimeEntryService
     public async Task<TimeEntryResponseWrapper> GetTimeEntries(int skip, int limit)
     {
         var userId = await GetUserIdAsync();
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
-        return await ToWrapper(UserEntries(ctx, userId), skip, limit);
+        return await ToWrapper((ctx, uid) => UserEntries(ctx, uid), userId, skip, limit);
     }
 
     public async Task<TimeEntryResponseWrapper> GetTimeEntriesByProjectId(int projectId, int skip, int limit)
     {
         var userId = await GetUserIdAsync();
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
-        return await ToWrapper(UserEntries(ctx, userId).Where(te => te.ProjectId == projectId), skip, limit);
+        return await ToWrapper((ctx, uid) => UserEntries(ctx, uid).Where(te => te.ProjectId == projectId), userId, skip, limit);
     }
 
     public async Task<TimeEntryResponseWrapper> GetTimeEntriesByYear(int year, int skip, int limit)
     {
         var userId = await GetUserIdAsync();
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
-        return await ToWrapper(UserEntries(ctx, userId).Where(te => te.Start.Year == year), skip, limit);
+        return await ToWrapper((ctx, uid) => UserEntries(ctx, uid).Where(te => te.Start.Year == year), userId, skip, limit);
     }
 
     public async Task<TimeEntryResponseWrapper> GetTimeEntriesByMonth(int month, int year, int skip, int limit)
     {
         var userId = await GetUserIdAsync();
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
-        return await ToWrapper(UserEntries(ctx, userId).Where(te => te.Start.Year == year && te.Start.Month == month), skip, limit);
+        return await ToWrapper((ctx, uid) => UserEntries(ctx, uid).Where(te => te.Start.Year == year && te.Start.Month == month), userId, skip, limit);
     }
 
     public async Task<TimeEntryResponseWrapper> GetTimeEntriesByDay(int day, int month, int year, int skip, int limit)
     {
         var userId = await GetUserIdAsync();
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
-        return await ToWrapper(UserEntries(ctx, userId)
-            .Where(te => te.Start.Year == year && te.Start.Month == month && te.Start.Day == day), skip, limit);
+        return await ToWrapper((ctx, uid) => UserEntries(ctx, uid)
+            .Where(te => te.Start.Year == year && te.Start.Month == month && te.Start.Day == day), userId, skip, limit);
     }
 
     public async Task<List<TimeEntryResponse>> GetAllTimeEntriesByYear(int year)
@@ -169,15 +161,31 @@ public class TimeEntryService : ITimeEntryService
         return entries.Adapt<List<TimeEntryResponse>>();
     }
 
-    private static async Task<TimeEntryResponseWrapper> ToWrapper(IQueryable<TimeEntry> query, int skip, int limit)
+    private async Task<TimeEntryResponseWrapper> ToWrapper(
+        Func<TimeTrackerDataContext, string, IQueryable<TimeEntry>> queryBuilder,
+        string userId, int skip, int limit)
     {
-        var all = await query.ToListAsync();
-        var paged = all.Skip(skip).Take(limit).Adapt<List<TimeEntryResponse>>();
+        await using var dataCtx = await _contextFactory.CreateDbContextAsync();
+        await using var countCtx = await _contextFactory.CreateDbContextAsync();
+        await using var durationCtx = await _contextFactory.CreateDbContextAsync();
+
+        var dataTask = queryBuilder(dataCtx, userId).Skip(skip).Take(limit).ToListAsync();
+        var countTask = queryBuilder(countCtx, userId).CountAsync();
+        var durationTask = queryBuilder(durationCtx, userId)
+            .Where(te => te.End.HasValue)
+            .Select(te => new { te.Start, End = te.End!.Value })
+            .ToListAsync();
+
+        await Task.WhenAll(dataTask, countTask, durationTask);
+
+        var totalDuration = durationTask.Result
+            .Aggregate(TimeSpan.Zero, (acc, e) => acc + (e.End - e.Start));
+
         return new TimeEntryResponseWrapper
         {
-            TimeEntries = paged,
-            Count = all.Count,
-            TotalDuration = CalculateTotalDuration(all)
+            TimeEntries = dataTask.Result.Adapt<List<TimeEntryResponse>>(),
+            Count = countTask.Result,
+            TotalDuration = totalDuration
         };
     }
 }


### PR DESCRIPTION
## Summary

- **Issue #13** (skip/limit silently ignored in month/day endpoints) was already resolved by the earlier minimal-API refactor — `TimeEntryEndpoints.cs` correctly forwards `skip` and `limit` to all service methods. Closing it here with no code change needed.
- **Issue #17** (sequential data+count DB queries): `ToWrapper` previously fetched *all* matching rows into memory and then paginated in C#. This PR fixes it properly:
  - `Skip`/`Take` are now applied on the `IQueryable` before `ToListAsync`, so only the requested page is fetched from the DB
  - Three independent queries (paginated data, total count, total duration) fire concurrently via `Task.WhenAll` using separate `DbContext` instances (EF Core does not allow concurrent operations on a shared context)
  - `TotalDuration` correctly sums across **all** matching entries (not just the current page) via a lightweight projection query — covered by a new test

## Test plan

- [ ] All 83 existing tests pass (`dotnet test`)
- [ ] New test `TotalDuration_ReflectsAllEntries_NotJustCurrentPage` verifies duration sums across pages even when `limit < total`

🤖 Generated with [Claude Code](https://claude.com/claude-code)