### PR TITLE
chore: add Google Search Console verification meta tag

### DIFF
--- a/TimeTracker.Web/App.razor
+++ b/TimeTracker.Web/App.razor
@@ -12,6 +12,7 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link rel="stylesheet" href="css/app.css" />
+    <meta name="google-site-verification" content="ejx4uqd9byj5sdsni_VyacQx21pD8_DqRW9Kp730WEA" />
     <HeadOutlet />
 </head>
 <body>


### PR DESCRIPTION
Adds the Google site verification meta tag to `App.razor` so ownership of `https://timetracker-zak.azurewebsites.net` can be confirmed in Search Console and a Safe Browsing review requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)