### PR TITLE
feat: Cloudflare Worker proxy for custom domain

### DIFF
--- a/docs/cloudflare-setup.md
+++ b/docs/cloudflare-setup.md
@@ -1,13 +1,24 @@
 # Cloudflare Custom Domain Setup
 
 One-time steps to route `timetracker.dzk.com.au` through Cloudflare to the existing App Service.
-After this guide is complete the custom domain is live with free managed SSL — no Azure changes required.
+A Cloudflare Worker handles the host header rewrite that App Service F1 requires.
+
+---
+
+## Why a Worker is needed
+
+App Service uses the `Host` header to route requests to the correct app. F1 does not support
+custom domain bindings, so it rejects any request where `Host` is not `*.azurewebsites.net`.
+When Cloudflare proxies `timetracker.dzk.com.au`, it forwards `Host: timetracker.dzk.com.au`
+to the origin — which App Service 404s. The Worker rewrites the outbound request URL to
+`timetracker-zak.azurewebsites.net`, causing the Workers runtime to set the Host header
+correctly without any paid Cloudflare plan features.
 
 ---
 
 ## Prerequisites
 
-- `dzk.com.au` nameservers pointing at Cloudflare (i.e. `dzk.com.au` is already a Cloudflare zone)
+- `dzk.com.au` nameservers pointing at Cloudflare
 - Access to [Google Cloud Console](https://console.cloud.google.com) to update the OAuth redirect URI
 - Access to the Azure Portal to add one App Service setting
 
@@ -15,7 +26,7 @@ After this guide is complete the custom domain is live with free managed SSL —
 
 ## Step 1 — Add a DNS record in Cloudflare
 
-In the Cloudflare dashboard, open the `dzk.com.au` zone → **DNS** → **Add record**:
+In the Cloudflare dashboard → `dzk.com.au` zone → **DNS** → **Add record**:
 
 | Field | Value |
 |-------|-------|
@@ -25,27 +36,49 @@ In the Cloudflare dashboard, open the `dzk.com.au` zone → **DNS** → **Add re
 | Proxy status | **Proxied** (orange cloud — must be on) |
 | TTL | Auto |
 
-The orange cloud is what routes traffic through Cloudflare and provides TLS termination. Do not set it to DNS-only (grey cloud).
-
 ---
 
 ## Step 2 — Set SSL/TLS mode to Full
 
 In the Cloudflare dashboard → **SSL/TLS** → **Overview**, select **Full**.
 
-| Mode | What it means |
-|------|---------------|
-| Flexible | Cloudflare → App Service over HTTP — do not use, causes header mismatch |
-| **Full** | Cloudflare → App Service over HTTPS — correct choice |
-| Full (Strict) | Same as Full but validates App Service cert — also works, optional |
-
-Full is correct here: Cloudflare terminates TLS from the browser, then connects to App Service over HTTPS using the `*.azurewebsites.net` certificate (which Azure manages automatically).
+Cloudflare terminates TLS from the browser, then connects to App Service over HTTPS using
+the `*.azurewebsites.net` certificate that Azure manages automatically.
 
 ---
 
-## Step 3 — Enable forwarded headers in App Service
+## Step 3 — Deploy the Cloudflare Worker
 
-This tells ASP.NET Core to trust the `X-Forwarded-Proto: https` header that Cloudflare sends, so HTTPS redirect and cookies behave correctly.
+The Worker script is at `workers/proxy.js` in this repository.
+
+1. Go to [dash.cloudflare.com](https://dash.cloudflare.com) → **Workers & Pages** → **Create** → **Create Worker**
+2. Name it `timetracker-proxy`, click **Deploy**
+3. Click **Edit code**, replace all content with the contents of `workers/proxy.js`, click **Deploy**
+
+### Attach the Worker to the custom domain
+
+4. Go to **Workers & Pages** → select `timetracker-proxy` → **Settings** → **Domains & Routes** → **Add** → **Route**
+5. Set:
+
+| Field | Value |
+|-------|-------|
+| Zone | `dzk.com.au` |
+| Route pattern | `timetracker.dzk.com.au/*` |
+
+6. Click **Add route**
+
+The Worker now intercepts all traffic to `timetracker.dzk.com.au` and proxies it to App Service
+with the correct Host header. WebSocket connections (Blazor SignalR) are also proxied.
+
+> **Free plan limits:** 100,000 requests/day. CPU time per request does not count network
+> wait — a simple proxy uses well under the 10 ms CPU limit.
+
+---
+
+## Step 4 — Enable forwarded headers in App Service
+
+Tells ASP.NET Core to trust `X-Forwarded-Proto: https` from Cloudflare so that HTTPS
+redirect and `SameSite=Strict` cookies behave correctly.
 
 In the Azure Portal → **App Services** → `timetracker-zak` → **Environment variables** → **Add**:
 
@@ -55,7 +88,7 @@ In the Azure Portal → **App Services** → `timetracker-zak` → **Environment
 
 Save and wait for the app to restart (~30 seconds).
 
-Alternatively via the Azure CLI:
+Or via Azure CLI:
 
 ```bash
 az webapp config appsettings set \
@@ -66,48 +99,30 @@ az webapp config appsettings set \
 
 ---
 
-## Step 4 — Update Google OAuth redirect URI
+## Step 5 — Update Google OAuth redirect URI
 
-Google rejects OAuth callbacks to URLs it has not seen before. You need to add the Cloudflare domain alongside the existing App Service URL.
-
-1. Go to [console.cloud.google.com](https://console.cloud.google.com)
-2. Select the project used for TimeTracker
-3. Navigate to **APIs & Services** → **Credentials**
-4. Click the OAuth 2.0 Client ID used by TimeTracker
-5. Under **Authorised redirect URIs**, add:
+1. Go to [console.cloud.google.com](https://console.cloud.google.com) → select the TimeTracker project
+2. **APIs & Services** → **Credentials** → click the OAuth 2.0 Client ID
+3. Under **Authorised redirect URIs** add:
 
 ```
 https://timetracker.dzk.com.au/signin-google
 ```
 
-Keep the existing `https://timetracker-zak.azurewebsites.net/signin-google` entry — removing it breaks direct App Service access.
+Keep the existing `https://timetracker-zak.azurewebsites.net/signin-google` entry.
 
-6. Click **Save**
-
-Changes propagate within a few minutes.
+4. Click **Save** — changes propagate within a few minutes
 
 ---
 
-## Step 5 — Verify
-
-Once DNS propagates (usually under 5 minutes with Cloudflare):
+## Step 6 — Verify
 
 ```bash
-# Should resolve via Cloudflare
+# Cloudflare should be in the response headers
 curl -I https://timetracker.dzk.com.au
 # Expect: HTTP/2 200 (or 302 to /login)
-# Check for: server: cloudflare
+# Expect: server: cloudflare
 ```
 
-Then open `https://timetracker.dzk.com.au` in a browser and complete a Google login to confirm the OAuth callback works end to end.
-
----
-
-## What Cloudflare provides
-
-| Feature | Detail |
-|---------|--------|
-| TLS certificate | Auto-provisioned, auto-renewed — no action required |
-| Origin IP hiding | App Service URL not exposed in DNS lookups |
-| DDoS mitigation | Basic protection included on free plan |
-| Cost | Free plan, hard-capped — no overage possible |
+Then open `https://timetracker.dzk.com.au` in a browser and complete a Google login to
+confirm the OAuth callback works end to end.

--- a/workers/proxy.js
+++ b/workers/proxy.js
@@ -1,0 +1,65 @@
+/**
+ * Cloudflare Worker — App Service reverse proxy
+ *
+ * Routes timetracker.dzk.com.au to timetracker-zak.azurewebsites.net.
+ * App Service F1 does not support custom domain bindings, so it rejects
+ * requests with Host: timetracker.dzk.com.au. This Worker rewrites the
+ * outbound request URL to the azurewebsites.net origin, which causes the
+ * Workers runtime to set Host automatically to that value.
+ */
+
+const ORIGIN = "https://timetracker-zak.azurewebsites.net";
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    const originUrl = ORIGIN + url.pathname + url.search;
+
+    // Strip the incoming Host header — the runtime sets it from the URL above.
+    // Preserve it as X-Forwarded-Host so ASP.NET Core uses the public hostname
+    // for OAuth callbacks and redirects (required for Google OAuth to work).
+    const headers = new Headers(request.headers);
+    headers.set("x-forwarded-host", url.hostname);
+    headers.delete("host");
+
+    if (request.headers.get("Upgrade")?.toLowerCase() === "websocket") {
+      return proxyWebSocket(originUrl, headers);
+    }
+
+    return fetch(new Request(originUrl, {
+      method: request.method,
+      headers,
+      body: request.body,
+      redirect: "follow",
+    }));
+  },
+};
+
+async function proxyWebSocket(originUrl, headers) {
+  const wsOriginUrl = originUrl.replace(/^https/, "wss");
+
+  const backendResponse = await fetch(wsOriginUrl, {
+    headers,
+    cf: { websocket: true },
+  });
+
+  const backendWs = backendResponse.webSocket;
+  if (!backendWs) {
+    return new Response("Backend did not accept WebSocket upgrade", { status: 502 });
+  }
+  backendWs.accept();
+
+  const [clientSocket, serverSocket] = Object.values(new WebSocketPair());
+  serverSocket.accept();
+
+  serverSocket.addEventListener("message", ({ data }) => backendWs.send(data));
+  backendWs.addEventListener("message", ({ data }) => serverSocket.send(data));
+
+  serverSocket.addEventListener("close", ({ code, reason }) => backendWs.close(code, reason));
+  backendWs.addEventListener("close", ({ code, reason }) => serverSocket.close(code, reason));
+
+  serverSocket.addEventListener("error", () => backendWs.close());
+  backendWs.addEventListener("error", () => serverSocket.close());
+
+  return new Response(null, { status: 101, webSocket: clientSocket });
+}


### PR DESCRIPTION
## Summary

- Adds `workers/proxy.js` — Cloudflare Worker that proxies `timetracker.dzk.com.au` to `timetracker-zak.azurewebsites.net` with the correct `Host` header
- Forwards `X-Forwarded-Host` so ASP.NET Core uses the public hostname for Google OAuth callbacks and redirects
- Proxies WebSocket connections (Blazor SignalR)
- Updates `docs/cloudflare-setup.md` with correct Worker-based deployment steps, replacing the Transform Rule / Origin Rule approach which does not work on the free plan

## What to do after merging

Follow `docs/cloudflare-setup.md` in order:
1. Add proxied CNAME in Cloudflare DNS
2. Set SSL/TLS to Full
3. Deploy `workers/proxy.js` as a Worker and attach route `timetracker.dzk.com.au/*`
4. Add `ASPNETCORE_FORWARDEDHEADERS_ENABLED=true` in App Service environment variables
5. Add `https://timetracker.dzk.com.au/signin-google` to Google OAuth authorised redirect URIs

## Test plan

- [ ] `curl -I https://timetracker.dzk.com.au` returns 200/302 with `server: cloudflare`
- [ ] Google login completes and lands on the app at `timetracker.dzk.com.au`

🤖 Generated with [Claude Code](https://claude.com/claude-code)