### PR TITLE
fix: Playwright auth state path and browser caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,10 +73,14 @@ jobs:
           dotnet restore TimeTracker.Playwright/TimeTracker.Playwright.csproj
           dotnet build TimeTracker.Playwright/TimeTracker.Playwright.csproj --no-restore --configuration Release
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ hashFiles('**/TimeTracker.Playwright.csproj') }}
+
       - name: Install Playwright browsers
-        run: |
-          dotnet tool install --global Microsoft.Playwright.CLI || true
-          pwsh TimeTracker.Playwright/bin/Release/net10.0/playwright.ps1 install chromium --with-deps
+        run: pwsh TimeTracker.Playwright/bin/Release/net10.0/playwright.ps1 install chromium --with-deps
 
       - name: Write auth storage state
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,8 +82,8 @@ jobs:
         env:
           PLAYWRIGHT_AUTH_STATE_B64: ${{ secrets.PLAYWRIGHT_AUTH_STATE_B64 }}
         run: |
-          mkdir -p TimeTracker.Playwright/playwright/.auth
-          echo "$PLAYWRIGHT_AUTH_STATE_B64" | base64 --decode > TimeTracker.Playwright/playwright/.auth/user.json
+          mkdir -p TimeTracker.Playwright/bin/Release/net10.0/playwright/.auth
+          echo "$PLAYWRIGHT_AUTH_STATE_B64" | base64 --decode > TimeTracker.Playwright/bin/Release/net10.0/playwright/.auth/user.json
 
       - name: Run Playwright tests
         env:


### PR DESCRIPTION
## Summary

- Fix auth storage state file written to wrong path (source tree instead of bin output directory where tests look for it)
- Cache Playwright Chromium browser between runs (saves ~1-2 min per deploy)
- Remove unused `dotnet tool install Microsoft.Playwright.CLI` step

## Test plan

- [ ] Deploy workflow runs successfully after merge
- [ ] Playwright job reads auth state without error
- [ ] All 30 tests pass against the live app
- [ ] Second run hits the browser cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)