### PR TITLE
fix: Playwright — wait for Blazor render, fix strict mode violations

### DIFF
--- a/TimeTracker.Playwright/Tests/ClientsTests.cs
+++ b/TimeTracker.Playwright/Tests/ClientsTests.cs
@@ -7,7 +7,7 @@ public class ClientsTests : AuthenticatedPageTest
     public async Task NavigateToClients()
     {
         await Page.GotoAsync("/clients");
-        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle, new() { Timeout = 30_000 });
+        await Expect(Page.Locator(".tt-fab button")).ToBeVisibleAsync(new() { Timeout = 30_000 });
     }
 
     [Test]

--- a/TimeTracker.Playwright/Tests/ProjectsTests.cs
+++ b/TimeTracker.Playwright/Tests/ProjectsTests.cs
@@ -7,7 +7,7 @@ public class ProjectsTests : AuthenticatedPageTest
     public async Task NavigateToProjects()
     {
         await Page.GotoAsync("/projects");
-        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle, new() { Timeout = 30_000 });
+        await Expect(Page.Locator(".tt-fab button")).ToBeVisibleAsync(new() { Timeout = 30_000 });
     }
 
     [Test]

--- a/TimeTracker.Playwright/Tests/ReportsTests.cs
+++ b/TimeTracker.Playwright/Tests/ReportsTests.cs
@@ -7,7 +7,8 @@ public class ReportsTests : AuthenticatedPageTest
     public async Task NavigateToReports()
     {
         await Page.GotoAsync("/reports");
-        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle, new() { Timeout = 30_000 });
+        // KPI cards are always rendered after Blazor connects
+        await Expect(Page.GetByText("YTD hours")).ToBeVisibleAsync(new() { Timeout = 30_000 });
     }
 
     [Test]
@@ -25,9 +26,8 @@ public class ReportsTests : AuthenticatedPageTest
     [Test]
     public async Task ReportsContentIsVisible()
     {
-        var hasContent = await Page.Locator(".mud-card, .mud-chart, canvas").CountAsync() > 0;
-        var hasEmptyState = await Page.GetByText(new Regex("no data|no entries|nothing", RegexOptions.IgnoreCase)).IsVisibleAsync();
-        Assert.That(hasContent || hasEmptyState, Is.True,
-            "Reports page should render chart content or an empty-state message");
+        // KPI cards are always rendered regardless of data — use them as the Blazor-ready signal
+        await Expect(Page.GetByText("YTD hours")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+        await Expect(Page.GetByText("Hours by month")).ToBeVisibleAsync();
     }
 }

--- a/TimeTracker.Playwright/Tests/TimeEntriesTests.cs
+++ b/TimeTracker.Playwright/Tests/TimeEntriesTests.cs
@@ -7,7 +7,7 @@ public class TimeEntriesTests : AuthenticatedPageTest
     public async Task NavigateToEntries()
     {
         await Page.GotoAsync("/entries");
-        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle, new() { Timeout = 30_000 });
+        await Expect(Page.Locator(".tt-fab button")).ToBeVisibleAsync(new() { Timeout = 30_000 });
     }
 
     [Test]

--- a/TimeTracker.Playwright/Tests/TimerTests.cs
+++ b/TimeTracker.Playwright/Tests/TimerTests.cs
@@ -7,7 +7,8 @@ public class TimerTests : AuthenticatedPageTest
     public async Task NavigateToTimer()
     {
         await Page.GotoAsync("/");
-        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle, new() { Timeout = 30_000 });
+        // FAB is always rendered after Blazor connects — reliable signal on F1 cold start
+        await Expect(Page.Locator(".tt-fab button")).ToBeVisibleAsync(new() { Timeout = 30_000 });
     }
 
     [Test]
@@ -32,7 +33,8 @@ public class TimerTests : AuthenticatedPageTest
     [Test]
     public async Task TodaySectionIsVisible()
     {
-        await Expect(Page.GetByText("Today")).ToBeVisibleAsync();
+        // Use heading role to avoid matching "No time logged yet today"
+        await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Today" })).ToBeVisibleAsync();
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- Replace `WaitForLoadStateAsync(NetworkIdle)` in all SetUps with a wait for a specific rendered element — `NetworkIdle` fires before Blazor connects on F1 cold start with `prerender:false` pages
- Fix `TodaySectionIsVisible`: use heading role to avoid strict mode violation (`GetByText("Today")` matched both the heading and "No time logged yet today")
- Fix `ReportsContentIsVisible`: assert specific always-present elements instead of counting `.mud-card`

## Test plan

- [ ] CI passes
- [ ] After merge, deploy + playwright job runs with 28 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)