### PR TITLE
fix: set Azure App Service startup command to prevent hostingstart.dll fallback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,11 @@ jobs:
           --configuration Release
           --output ./publish
 
+      - name: Set startup command
+        run: |
+          RG=$(az webapp list --query "[?name=='${{ vars.AZURE_WEBAPP_NAME }}'].resourceGroup" -o tsv)
+          az webapp config set --name ${{ vars.AZURE_WEBAPP_NAME }} --resource-group "$RG" --startup-file "dotnet TimeTracker.Web.dll"
+
       - name: Deploy to Azure App Service
         id: deploy
         uses: azure/webapps-deploy@v3


### PR DESCRIPTION
## Problem

Phase 10 added `TimeTracker.Client` (BlazorWebAssembly SDK) as a project reference to `TimeTracker.Web`. Publishing `TimeTracker.Web` now emits **two** `.runtimeconfig.json` files into the output directory:

- `TimeTracker.Client.runtimeconfig.json`
- `TimeTracker.Web.runtimeconfig.json`

Azure App Service auto-detection requires exactly one `.runtimeconfig.json` to identify the startup DLL. When it finds two, it logs a warning and falls back to running `dotnet /defaulthome/hostingstart/hostingstart.dll` — Microsoft's placeholder app. The real app never starts.

Evidence from `2026_06_08_10-30-0-214_default_docker.log`:
```
WARNING: Expected to find only one file with extension '.runtimeconfig.json' but found 2
WARNING: Found files: 'TimeTracker.Client.runtimeconfig.json, TimeTracker.Web.runtimeconfig.json'
Running the default app using command: dotnet "/defaulthome/hostingstart/hostingstart.dll"
```

## Fix

Set `--startup-file "dotnet TimeTracker.Web.dll"` on the App Service before every deploy. This bypasses auto-detection entirely and pins the startup DLL explicitly.

The startup command was also applied directly to the running App Service via `az webapp config set` + restart (production is already recovered).

## Test plan
- [ ] Deploy job sets startup command before uploading the package
- [ ] App Service starts `TimeTracker.Web.dll`, not `hostingstart.dll`
- [ ] Playwright tests pass post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)