### PR TITLE
feat: Phase 11 — GitHub Pages showcase

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  pages: write
 
 jobs:
   check:
@@ -127,3 +128,38 @@ jobs:
           name: playwright-results
           path: TimeTracker.Playwright/TestResults/
           retention-days: 14
+
+  showcase:
+    name: Deploy Showcase to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: check
+    if: ${{ needs.check.outputs.code == 'true' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Publish Showcase
+        run: >
+          dotnet publish TimeTracker.Client/TimeTracker.Client.csproj
+          --configuration Release
+          -p:DefineConstants=SHOWCASE
+          --output ./showcase-output
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./showcase-output/wwwroot
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/TimeTracker.Client/Mock/MockAuthenticationStateProvider.cs
+++ b/TimeTracker.Client/Mock/MockAuthenticationStateProvider.cs
@@ -1,0 +1,19 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Components.Authorization;
+
+namespace TimeTracker.Client.Mock;
+
+public class MockAuthenticationStateProvider : AuthenticationStateProvider
+{
+    public override Task<AuthenticationState> GetAuthenticationStateAsync()
+    {
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.Name, "demo@example.com"),
+            new Claim(ClaimTypes.Email, "demo@example.com"),
+            new Claim(ClaimTypes.Role, "Admin"),
+        };
+        var identity = new ClaimsIdentity(claims, "Demo");
+        return Task.FromResult(new AuthenticationState(new ClaimsPrincipal(identity)));
+    }
+}

--- a/TimeTracker.Client/Mock/MockClientService.cs
+++ b/TimeTracker.Client/Mock/MockClientService.cs
@@ -1,0 +1,64 @@
+using TimeTracker.Contracts.Features.Clients;
+
+namespace TimeTracker.Client.Mock;
+
+public class MockClientService(MockDataStore store) : IClientService
+{
+    public Task<List<ClientResponse>> GetAllClients(bool includeArchived = false) =>
+        Task.FromResult(store.Clients
+            .Where(c => includeArchived || !c.IsArchived)
+            .ToList());
+
+    public Task<ClientResponse?> GetClientById(int id) =>
+        Task.FromResult(store.Clients.FirstOrDefault(c => c.Id == id));
+
+    public Task CreateClient(ClientCreateRequest request)
+    {
+        store.Clients.Add(new ClientResponse(
+            store.NextClientId(),
+            request.Name,
+            false,
+            request.DefaultHourlyRate,
+            request.ContactName,
+            request.ContactEmail,
+            request.ContactPhone));
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateClient(int id, ClientUpdateRequest request)
+    {
+        var i = store.Clients.FindIndex(c => c.Id == id);
+        if (i < 0) return Task.CompletedTask;
+
+        var old = store.Clients[i];
+        store.Clients[i] = new ClientResponse(
+            old.Id,
+            request.Name,
+            old.IsArchived,
+            request.DefaultHourlyRate,
+            request.ContactName,
+            request.ContactEmail,
+            request.ContactPhone);
+        return Task.CompletedTask;
+    }
+
+    public Task ArchiveClient(int id)
+    {
+        var i = store.Clients.FindIndex(c => c.Id == id);
+        if (i >= 0) store.Clients[i] = store.Clients[i] with { IsArchived = true };
+        return Task.CompletedTask;
+    }
+
+    public Task UnarchiveClient(int id)
+    {
+        var i = store.Clients.FindIndex(c => c.Id == id);
+        if (i >= 0) store.Clients[i] = store.Clients[i] with { IsArchived = false };
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteClient(int id)
+    {
+        store.Clients.RemoveAll(c => c.Id == id);
+        return Task.CompletedTask;
+    }
+}

--- a/TimeTracker.Client/Mock/MockDataStore.cs
+++ b/TimeTracker.Client/Mock/MockDataStore.cs
@@ -1,0 +1,158 @@
+using TimeTracker.Contracts.Features.Clients;
+using TimeTracker.Contracts.Features.Projects;
+using TimeTracker.Contracts.Features.TimeEntries;
+
+namespace TimeTracker.Client.Mock;
+
+public class MockDataStore
+{
+    private int _nextEntryId;
+    private int _nextProjectId;
+    private int _nextClientId;
+
+    public List<ClientResponse> Clients { get; }
+    public List<ProjectResponse> Projects { get; }
+    public List<TimeEntryResponse> TimeEntries { get; }
+
+    public MockDataStore()
+    {
+        Clients = SeedClients();
+        Projects = SeedProjects();
+        TimeEntries = SeedEntries(Projects);
+        _nextClientId = Clients.Max(c => c.Id) + 1;
+        _nextProjectId = Projects.Max(p => p.Id) + 1;
+        _nextEntryId = TimeEntries.Max(e => e.Id) + 1;
+    }
+
+    public int NextEntryId() => _nextEntryId++;
+    public int NextProjectId() => _nextProjectId++;
+    public int NextClientId() => _nextClientId++;
+
+    private static List<ClientResponse> SeedClients() =>
+    [
+        new(1, "Acme Corp",    false, 150m, "Jane Smith", "jane@acme.example",      "+1 555-0101"),
+        new(2, "Beta Digital", false, 175m, "Tom Lee",    "tom@betadigital.example", "+1 555-0202"),
+    ];
+
+    private static List<ProjectResponse> SeedProjects() =>
+    [
+        new(1, "Website Redesign", 1, "Acme Corp",    150m, "Full site refresh",               new DateTime(2026, 1, 1), null),
+        new(2, "API Integration",  1, "Acme Corp",    150m, "REST API integration layer",       new DateTime(2026, 2, 1), null),
+        new(3, "Mobile App",       2, "Beta Digital", 175m, "Cross-platform mobile app",        new DateTime(2026, 3, 1), null),
+        new(4, "Admin & Overhead", null, null,        null, "Internal admin and overhead time",  null,                   null),
+    ];
+
+    private static List<TimeEntryResponse> SeedEntries(List<ProjectResponse> projects)
+    {
+        var today = DateTime.Today;
+        var entries = new List<TimeEntryResponse>();
+        int id = 1;
+
+        TimeEntryResponse E(int projectId, DateTime start, int minutes, string? invoice = null)
+        {
+            var p = projects.First(x => x.Id == projectId);
+            var result = new TimeEntryResponse(
+                id,
+                new ProjectSummary(p.Id, p.Name),
+                start,
+                start.AddMinutes(minutes),
+                null,
+                invoice,
+                invoice != null ? (DateTime?)start.Date : null);
+            id++;
+            return result;
+        }
+
+        // Today
+        entries.Add(E(1, today.AddHours(9),   120));
+        entries.Add(E(1, today.AddHours(13),   90));
+
+        // Yesterday
+        entries.Add(E(3, today.AddDays(-1).AddHours(9),  150));
+        entries.Add(E(1, today.AddDays(-1).AddHours(14),  90));
+
+        // 2 days ago
+        entries.Add(E(2, today.AddDays(-2).AddHours(10), 120));
+
+        // 5 days ago
+        entries.Add(E(1, today.AddDays(-5).AddHours(9),  180));
+        entries.Add(E(3, today.AddDays(-5).AddHours(14), 120));
+
+        // 7 days ago
+        entries.Add(E(2, today.AddDays(-7).AddHours(10), 150, "INV-2026-005"));
+        entries.Add(E(3, today.AddDays(-7).AddHours(14),  90));
+
+        // 10 days ago
+        entries.Add(E(1, today.AddDays(-10).AddHours(9),  90));
+        entries.Add(E(4, today.AddDays(-10).AddHours(11), 60));
+
+        // 14 days ago
+        entries.Add(E(2, today.AddDays(-14).AddHours(9),  180, "INV-2026-005"));
+        entries.Add(E(3, today.AddDays(-14).AddHours(14), 120));
+
+        // 17 days ago
+        entries.Add(E(1, today.AddDays(-17).AddHours(9),  150));
+        entries.Add(E(2, today.AddDays(-17).AddHours(14),  90));
+
+        // 21 days ago
+        entries.Add(E(1, today.AddDays(-21).AddHours(9),  120));
+        entries.Add(E(3, today.AddDays(-21).AddHours(13), 180));
+
+        // 28 days ago
+        entries.Add(E(1, today.AddDays(-28).AddHours(9),  150, "INV-2026-004"));
+        entries.Add(E(2, today.AddDays(-28).AddHours(13), 120, "INV-2026-004"));
+        entries.Add(E(3, today.AddDays(-28).AddHours(16),  60));
+
+        // 35 days ago
+        entries.Add(E(2, today.AddDays(-35).AddHours(9),  180, "INV-2026-004"));
+        entries.Add(E(3, today.AddDays(-35).AddHours(14), 150, "INV-2026-004"));
+
+        // 42 days ago
+        entries.Add(E(1, today.AddDays(-42).AddHours(9),  120));
+        entries.Add(E(2, today.AddDays(-42).AddHours(13), 120));
+
+        // 49 days ago
+        entries.Add(E(1, today.AddDays(-49).AddHours(9),  90));
+        entries.Add(E(3, today.AddDays(-49).AddHours(11), 150));
+
+        // 56 days ago
+        entries.Add(E(2, today.AddDays(-56).AddHours(9),  180, "INV-2026-003"));
+        entries.Add(E(4, today.AddDays(-56).AddHours(14),  60));
+
+        // 63 days ago
+        entries.Add(E(1, today.AddDays(-63).AddHours(9),  120, "INV-2026-003"));
+        entries.Add(E(2, today.AddDays(-63).AddHours(12), 120, "INV-2026-003"));
+        entries.Add(E(3, today.AddDays(-63).AddHours(15),  90));
+
+        // 70 days ago
+        entries.Add(E(1, today.AddDays(-70).AddHours(9),  150, "INV-2026-003"));
+        entries.Add(E(3, today.AddDays(-70).AddHours(14), 120));
+
+        // 84 days ago
+        entries.Add(E(2, today.AddDays(-84).AddHours(9),  180, "INV-2026-002"));
+        entries.Add(E(3, today.AddDays(-84).AddHours(14), 150, "INV-2026-002"));
+
+        // 98 days ago
+        entries.Add(E(1, today.AddDays(-98).AddHours(9),  120, "INV-2026-002"));
+        entries.Add(E(2, today.AddDays(-98).AddHours(13), 120, "INV-2026-002"));
+
+        // 112 days ago
+        entries.Add(E(1, today.AddDays(-112).AddHours(9),  180, "INV-2026-001"));
+        entries.Add(E(3, today.AddDays(-112).AddHours(13), 150, "INV-2026-001"));
+        entries.Add(E(4, today.AddDays(-112).AddHours(16),  60));
+
+        // 126 days ago
+        entries.Add(E(2, today.AddDays(-126).AddHours(9),  150, "INV-2026-001"));
+        entries.Add(E(3, today.AddDays(-126).AddHours(13), 120, "INV-2026-001"));
+
+        // 140 days ago
+        entries.Add(E(1, today.AddDays(-140).AddHours(9),  180, "INV-2026-001"));
+        entries.Add(E(2, today.AddDays(-140).AddHours(13), 120, "INV-2026-001"));
+
+        // 154 days ago
+        entries.Add(E(1, today.AddDays(-154).AddHours(9),  150, "INV-2026-001"));
+        entries.Add(E(3, today.AddDays(-154).AddHours(13), 120, "INV-2026-001"));
+
+        return entries;
+    }
+}

--- a/TimeTracker.Client/Mock/MockProjectService.cs
+++ b/TimeTracker.Client/Mock/MockProjectService.cs
@@ -1,0 +1,56 @@
+using TimeTracker.Contracts.Features.Projects;
+
+namespace TimeTracker.Client.Mock;
+
+public class MockProjectService(MockDataStore store) : IProjectService
+{
+    public Task<List<ProjectResponse>> GetAllProjects() =>
+        Task.FromResult(store.Projects.ToList());
+
+    public Task<ProjectResponse?> GetProjectById(int id) =>
+        Task.FromResult(store.Projects.FirstOrDefault(p => p.Id == id));
+
+    public Task CreateProject(ProjectCreateRequest request)
+    {
+        var client = request.ClientId.HasValue
+            ? store.Clients.FirstOrDefault(c => c.Id == request.ClientId.Value)
+            : null;
+        store.Projects.Add(new ProjectResponse(
+            store.NextProjectId(),
+            request.Name,
+            request.ClientId,
+            client?.Name,
+            request.HourlyRate,
+            request.Description,
+            request.StartDate,
+            request.EndDate));
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateProject(int id, ProjectUpdateRequest request)
+    {
+        var i = store.Projects.FindIndex(p => p.Id == id);
+        if (i < 0) return Task.CompletedTask;
+
+        var old = store.Projects[i];
+        var client = request.ClientId.HasValue
+            ? store.Clients.FirstOrDefault(c => c.Id == request.ClientId.Value)
+            : null;
+        store.Projects[i] = new ProjectResponse(
+            old.Id,
+            request.Name,
+            request.ClientId,
+            client?.Name,
+            request.HourlyRate,
+            request.Description,
+            request.StartDate,
+            request.EndDate);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteProject(int id)
+    {
+        store.Projects.RemoveAll(p => p.Id == id);
+        return Task.CompletedTask;
+    }
+}

--- a/TimeTracker.Client/Mock/MockTimeEntryService.cs
+++ b/TimeTracker.Client/Mock/MockTimeEntryService.cs
@@ -1,0 +1,72 @@
+using TimeTracker.Contracts.Features.Projects;
+using TimeTracker.Contracts.Features.TimeEntries;
+
+namespace TimeTracker.Client.Mock;
+
+public class MockTimeEntryService(MockDataStore store) : ITimeEntryService
+{
+    public Task<TimeEntryResponse?> GetActiveTimeEntry() =>
+        Task.FromResult(store.TimeEntries.FirstOrDefault(e => !e.End.HasValue));
+
+    public Task<List<TimeEntryResponse>> GetTodaysTimeEntries() =>
+        Task.FromResult(store.TimeEntries
+            .Where(e => e.Start.Date == DateTime.Today)
+            .OrderByDescending(e => e.Start)
+            .ToList());
+
+    public Task<List<TimeEntryResponse>> GetAllTimeEntriesByYear(int year) =>
+        Task.FromResult(store.TimeEntries
+            .Where(e => e.Start.Year == year)
+            .OrderByDescending(e => e.Start)
+            .ToList());
+
+    public Task<List<TimeEntryResponse>> GetAllTimeEntriesByProject(int projectId) =>
+        Task.FromResult(store.TimeEntries
+            .Where(e => e.Project.Id == projectId)
+            .OrderByDescending(e => e.Start)
+            .ToList());
+
+    public Task<TimeEntryResponse?> GetTimeEntryById(int id) =>
+        Task.FromResult(store.TimeEntries.FirstOrDefault(e => e.Id == id));
+
+    public Task CreateTimeEntry(TimeEntryCreateRequest request)
+    {
+        var project = store.Projects.First(p => p.Id == request.ProjectId);
+        store.TimeEntries.Add(new TimeEntryResponse(
+            store.NextEntryId(),
+            new ProjectSummary(project.Id, project.Name),
+            request.Start,
+            request.End,
+            request.Note,
+            null,
+            null));
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateTimeEntry(int id, TimeEntryUpdateRequest request)
+    {
+        var i = store.TimeEntries.FindIndex(e => e.Id == id);
+        if (i < 0) return Task.CompletedTask;
+
+        var old = store.TimeEntries[i];
+        var project = request.ProjectId.HasValue
+            ? store.Projects.First(p => p.Id == request.ProjectId.Value)
+            : store.Projects.First(p => p.Id == old.Project.Id);
+
+        store.TimeEntries[i] = new TimeEntryResponse(
+            old.Id,
+            new ProjectSummary(project.Id, project.Name),
+            request.Start,
+            request.End,
+            request.Note,
+            request.InvoiceReference,
+            request.InvoicedAt);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteTimeEntry(int id)
+    {
+        store.TimeEntries.RemoveAll(e => e.Id == id);
+        return Task.CompletedTask;
+    }
+}

--- a/TimeTracker.Client/Program.cs
+++ b/TimeTracker.Client/Program.cs
@@ -13,18 +13,25 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
 builder.Services.AddAuthorizationCore();
 builder.Services.AddCascadingAuthenticationState();
-builder.Services.AddScoped<AuthenticationStateProvider, CookieAuthenticationStateProvider>();
-
 builder.Services.AddMudServices();
 
+#if SHOWCASE
+builder.Services.AddScoped<AuthenticationStateProvider, TimeTracker.Client.Mock.MockAuthenticationStateProvider>();
+builder.Services.AddScoped(_ => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddSingleton<TimeTracker.Client.Mock.MockDataStore>();
+builder.Services.AddScoped<ITimeEntryService, TimeTracker.Client.Mock.MockTimeEntryService>();
+builder.Services.AddScoped<IProjectService, TimeTracker.Client.Mock.MockProjectService>();
+builder.Services.AddScoped<IClientService, TimeTracker.Client.Mock.MockClientService>();
+#else
+builder.Services.AddScoped<AuthenticationStateProvider, CookieAuthenticationStateProvider>();
 builder.Services.AddScoped(sp =>
     new HttpClient(new TimeTracker.Client.CookieCredentialHandler())
     {
         BaseAddress = new Uri(builder.HostEnvironment.BaseAddress)
     });
-
 builder.Services.AddScoped<ITimeEntryService, HttpTimeEntryService>();
 builder.Services.AddScoped<IProjectService, HttpProjectService>();
 builder.Services.AddScoped<IClientService, HttpClientService>();
+#endif
 
 await builder.Build().RunAsync();

--- a/TimeTracker.Client/wwwroot/404.html
+++ b/TimeTracker.Client/wwwroot/404.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>TimeTracker Demo</title>
+    <script>
+        // SPA routing for GitHub Pages: redirect deep links back through index.html.
+        // pathSegmentsToKeep=1 preserves the /TimeTracker/ repo prefix.
+        var pathSegmentsToKeep = 1;
+        var l = window.location;
+        l.replace(
+            l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+            l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+            l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+            (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+            l.hash
+        );
+    </script>
+</head>
+<body></body>
+</html>

--- a/TimeTracker.Client/wwwroot/css/showcase-app.css
+++ b/TimeTracker.Client/wwwroot/css/showcase-app.css
@@ -1,0 +1,266 @@
+/* TimeTracker — custom styles layered on top of MudBlazor */
+
+:root {
+    --dzk-navy: #002F6F;
+}
+
+html, body, #app {
+    height: 100%;
+}
+
+/* ── Bottom navigation (mobile) ── */
+.bottom-nav {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 62px;
+    background: var(--mud-palette-surface);
+    border-top: 1px solid var(--mud-palette-divider);
+    display: flex;
+    align-items: stretch;
+    z-index: 1200;
+    box-shadow: 0 -1px 6px rgba(0,0,0,.10);
+}
+
+.bottom-nav-item {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    cursor: pointer;
+    color: var(--mud-palette-text-secondary);
+    transition: color 0.15s;
+    padding-top: 6px;
+    text-decoration: none;
+    border: none;
+    background: transparent;
+}
+
+.bottom-nav-item .mud-icon-root {
+    font-size: 24px !important;
+    transition: transform 0.15s;
+}
+
+.bottom-nav-item .nav-label {
+    font-size: 0.68rem;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+}
+
+.bottom-nav-item.active {
+    color: var(--mud-palette-primary);
+}
+
+.bottom-nav-item.active .mud-icon-root {
+    transform: translateY(-1px);
+}
+
+/* ── FAB (floating action button) — above bottom nav on mobile ── */
+.tt-fab {
+    position: fixed;
+    bottom: calc(62px + 16px);
+    right: 16px;
+    z-index: 1300;
+}
+
+/* FAB uses Material Design 3 border-radius (16px) */
+.tt-fab .mud-fab {
+    border-radius: 16px !important;
+}
+
+@media (min-width: 960px) {
+    .bottom-nav {
+        display: none;
+    }
+
+    .tt-fab {
+        bottom: 24px;
+        right: 24px;
+    }
+}
+
+/* ── Spacer so content clears the bottom nav on mobile ── */
+.bottom-nav-spacer {
+    height: 78px;
+}
+
+@media (min-width: 960px) {
+    .bottom-nav-spacer {
+        display: none;
+    }
+}
+
+/* ── Project colour dot ── */
+.project-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    display: inline-block;
+}
+
+/* ── Timer hero card gradient ── */
+.timer-card-running {
+    background: linear-gradient(135deg, #002F6F 0%, #013a86 60%, #0068CD 130%) !important;
+    color: #fff !important;
+}
+
+/* ── Pulse dot (live indicator) ── */
+.pulse-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #ff5252;
+    display: inline-block;
+    box-shadow: 0 0 0 0 rgba(255,82,82,.6);
+    animation: pulse-anim 1.6s infinite;
+}
+
+@keyframes pulse-anim {
+    0%   { box-shadow: 0 0 0 0 rgba(255,82,82,.55); }
+    70%  { box-shadow: 0 0 0 7px rgba(255,82,82,0); }
+    100% { box-shadow: 0 0 0 0 rgba(255,82,82,0); }
+}
+
+/* ── Tabular numbers ── */
+.tabnum {
+    font-variant-numeric: tabular-nums;
+}
+
+/* ── Filter tab bar (Entries page) ── */
+.tt-filter-tabs {
+    display: flex;
+    position: relative;
+    border-bottom: 1px solid var(--mud-palette-divider);
+    background: var(--mud-palette-surface);
+}
+
+.tt-filter-tab {
+    flex: 1;
+    text-align: center;
+    padding: 13px 8px;
+    cursor: pointer;
+    font-size: .8125rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    color: var(--mud-palette-text-secondary);
+    position: relative;
+    border: none;
+    background: transparent;
+    transition: color .15s, background .15s;
+    user-select: none;
+}
+
+.tt-filter-tab:hover {
+    background: var(--mud-palette-action-default-hover);
+    color: var(--mud-palette-text-primary);
+}
+
+.tt-filter-tab.active {
+    color: var(--mud-palette-primary);
+}
+
+.tt-filter-tab.active::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -1px;
+    height: 2px;
+    background: var(--mud-palette-primary);
+}
+
+/* ── MudNavMenu — nav link styles matching mockup ── */
+.mud-nav-link {
+    border-radius: 6px !important;
+    margin: 2px 8px !important;
+    font-weight: 600 !important;
+    min-height: 46px;
+}
+
+.mud-nav-link:hover {
+    background: rgba(0,0,0,0.06) !important;
+    border-radius: 6px !important;
+}
+
+.mud-nav-link.active {
+    background: rgba(0,104,205,0.10) !important;
+    color: var(--mud-palette-primary) !important;
+    border-radius: 6px !important;
+}
+
+.mud-nav-link.active .mud-icon-root {
+    color: var(--mud-palette-primary) !important;
+}
+
+/* ── Entry sheet — bottom sheet ── */
+.entry-sheet .mud-drawer-content {
+    max-height: 92vh;
+    overflow-y: auto;
+}
+.entry-sheet .mud-drawer-header {
+    border-bottom: none !important;
+}
+
+/* ── Grip pill (drag handle at top of bottom sheet) ── */
+.sheet-grip-pill {
+    width: 36px;
+    height: 4px;
+    border-radius: 2px;
+    background: rgba(0,0,0,.18);
+    margin: 10px auto 4px;
+    flex-shrink: 0;
+}
+
+/* ── KPI grid ── */
+.kpi-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+}
+
+/* ── Summary card (navy background) ── */
+.summary-card {
+    background: #002F6F !important;
+    color: #fff !important;
+    border-radius: 12px !important;
+}
+
+/* ── Today's progress bar — rounded, correct track/fill colours ── */
+.tt-progress {
+    height: 8px !important;
+    border-radius: 99px !important;
+    background: rgba(0,0,0,.07) !important;
+}
+.tt-progress .mud-progress-linear-bar1,
+.tt-progress .mud-progress-linear-bar2 {
+    border-radius: 99px !important;
+}
+
+/* ── Outlined input label — primary colour when floating (field has value) ── */
+.mud-input-outlined.mud-input-label-animated .mud-input-label-animated {
+    color: var(--mud-palette-primary) !important;
+}
+label.mud-input-label.mud-input-label-animated.mud-input-label-inputcontrol {
+    color: var(--mud-palette-primary) !important;
+}
+
+/* ── Archived items ── */
+.archived-item {
+    opacity: 0.68;
+}
+
+/* ── Project avatar (square) ── */
+.avatar-sq {
+    border-radius: 6px !important;
+}
+
+/* ── Rate chip (cyan tint) ── */
+.rate-chip-cyan {
+    background: rgba(31,172,242,0.14) !important;
+    color: #0a6ea3 !important;
+}

--- a/TimeTracker.Client/wwwroot/index.html
+++ b/TimeTracker.Client/wwwroot/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TimeTracker Demo</title>
+    <base href="/TimeTracker/" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="css/showcase-app.css" />
+    <script>
+        // SPA routing for GitHub Pages: restore path encoded by 404.html
+        (function(l) {
+            if (l.search[1] === '/') {
+                var decoded = l.search.slice(1).split('&').map(function(s) {
+                    return s.replace(/~and~/g, '&');
+                });
+                window.history.replaceState(null, null,
+                    l.pathname.slice(0, -1) + decoded[0] +
+                    (decoded[1] ? '&' + decoded[1] : '') +
+                    l.hash);
+            }
+        }(window.location));
+    </script>
+</head>
+<body>
+    <app>
+        <div style="display:flex;align-items:center;justify-content:center;height:100vh">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" style="width:48px;height:48px">
+                <circle cx="50" cy="50" r="42" stroke="#0068CD" stroke-width="8" fill="none"
+                        stroke-dasharray="264" stroke-dashoffset="66">
+                    <animateTransform attributeName="transform" type="rotate"
+                                      from="0 50 50" to="360 50 50" dur="1s" repeatCount="indefinite"/>
+                </circle>
+            </svg>
+        </div>
+    </app>
+    <div id="blazor-error-ui" style="display:none;position:fixed;bottom:0;left:0;right:0;padding:12px;background:#f8d7da;text-align:center;z-index:99999">
+        An unhandled error has occurred. <a href="" class="reload">Reload</a>
+    </div>
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- `Mock/`: `MockDataStore` (singleton, ~50 seeded entries across 5 months), `MockTimeEntryService`, `MockProjectService`, `MockClientService`, `MockAuthenticationStateProvider` (Admin role, no login required)
- `Program.cs`: `#if SHOWCASE` block swaps HTTP services for mocks; `#else` branch is the existing production wiring — unchanged
- `wwwroot/index.html` + `404.html`: standalone WASM host page (`base href="/TimeTracker/"`) with SPA routing restore script for GitHub Pages deep links
- `wwwroot/css/showcase-app.css`: app styles under unique filename (avoids static asset path collision with `TimeTracker.Web/wwwroot/css/app.css`)
- `deploy.yml`: `showcase` job publishes `TimeTracker.Client` with `-p:DefineConstants=SHOWCASE` and deploys to GitHub Pages in parallel with the Azure deploy; `pages:write` permission added

## Test plan

- [ ] Full solution build clean — verified locally
- [ ] Showcase build clean — verified locally
- [ ] 105 unit tests pass — verified locally
- [ ] 10/10 unauthenticated Playwright tests pass — verified via pre-push hook
- [ ] **Before merging:** enable GitHub Pages on the repo (Settings → Pages → source: GitHub Actions)
- [ ] After merge: verify showcase loads at `https://zkarachiwala.github.io/TimeTracker/`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)