### PR TITLE
fix: add concurrency group to prevent duplicate Pages deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,10 @@ permissions:
   contents: read
   pages: write
 
+concurrency:
+  group: deploy-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
 jobs:
   check:
     name: Check for code changes


### PR DESCRIPTION
## Summary

- `upload-pages-artifact` writes to the GitHub Pages API at repository scope, not per workflow run
- If two deploy workflow runs are in flight simultaneously, both upload a `github-pages` artifact and `deploy-pages` fails with "Multiple artifacts named 'github-pages' were unexpectedly found"
- Adds `concurrency: group: deploy-<sha>` to prevent parallel deploy runs for the same commit

## Test plan

- [ ] CI passes
- [ ] GitHub Pages deploys successfully on next merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)