### PR TITLE
fix: add workflow_dispatch to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     workflows: ["CI"]
     branches: [main]
     types: [completed]
+  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -12,26 +13,29 @@ permissions:
   pages: write
 
 concurrency:
-  group: deploy-${{ github.event.workflow_run.head_sha }}
+  group: deploy-${{ github.event.workflow_run.head_sha || github.sha }}
   cancel-in-progress: false
 
 jobs:
   check:
     name: Check for code changes
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
       code: ${{ steps.diff.outputs.code }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 2
 
       - name: Diff against parent commit
         id: diff
         run: |
-          if git diff --name-only HEAD~1 HEAD | grep -qE '\.(cs|razor|csproj|sln|css)$'; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "code=true" >> $GITHUB_OUTPUT
+            echo "Manual dispatch — deploying everything."
+          elif git diff --name-only HEAD~1 HEAD | grep -qE '\.(cs|razor|csproj|sln|css)$'; then
             echo "code=true" >> $GITHUB_OUTPUT
           else
             echo "code=false" >> $GITHUB_OUTPUT
@@ -51,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Azure Login
         uses: azure/login@v2
@@ -95,7 +99,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -145,7 +149,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger so the deploy workflow can be run manually from the Actions tab
- When manually triggered: `check` job always sets `code=true` (deploys everything — Azure + GitHub Pages)
- All `ref:` checkouts fall back to `github.sha` when `github.event.workflow_run.head_sha` is null
- Concurrency group uses the same fallback

## Why

Workflow-only commits (`.yml` changes with no `.cs`/`.razor`/`.csproj`) produce no automatic deploy run. Without `workflow_dispatch` there's no way to trigger Pages or Azure deploys without a dummy code change.

## Test plan

- [ ] Merge and manually trigger via Actions → Deploy → Run workflow
- [ ] GitHub Pages deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)