### PR TITLE
fix: change <app> to <div id="app"> in showcase index.html

### DIFF
--- a/TimeTracker.Client/wwwroot-showcase/index.html
+++ b/TimeTracker.Client/wwwroot-showcase/index.html
@@ -27,7 +27,7 @@
     </script>
 </head>
 <body>
-    <app>
+    <div id="app">
         <div style="display:flex;align-items:center;justify-content:center;height:100vh">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" style="width:48px;height:48px">
                 <circle cx="50" cy="50" r="42" stroke="#0068CD" stroke-width="8" fill="none"
@@ -37,7 +37,7 @@
                 </circle>
             </svg>
         </div>
-    </app>
+    </div>
     <div id="blazor-error-ui" style="display:none;position:fixed;bottom:0;left:0;right:0;padding:12px;background:#f8d7da;text-align:center;z-index:99999">
         An unhandled error has occurred. <a href="" class="reload">Reload</a>
     </div>


### PR DESCRIPTION
## Summary

`Program.cs` registers root components against `#app` (CSS id selector). The showcase `index.html` used `<app>` (HTML tag element) which doesn't match — Blazor threw `Could not find any element matching selector '#app'` on load. Fixed by using `<div id="app">`.

## Test plan

- [ ] Merge, manually trigger Deploy workflow, verify GitHub Pages loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)