### PR TITLE
feat: add scripts/serve-showcase.sh for local nginx testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -355,3 +355,6 @@ MigrationBackup/
 # .NET User Secrets (stored outside project dir by tooling, but explicit exclusion as safeguard)
 **/secrets.json
 **/secrets.*.json
+
+# Local showcase publish output
+.showcase-local/

--- a/scripts/serve-showcase.sh
+++ b/scripts/serve-showcase.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Builds and serves the GitHub Pages showcase locally via nginx in Docker.
+# Mirrors production: served at /TimeTracker/ with SPA fallback.
+# Access at http://localhost:8080/TimeTracker/
+#
+# Usage: ./scripts/serve-showcase.sh
+# Requires: Docker Desktop running, .NET 10 SDK
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+OUTPUT_DIR="$REPO_ROOT/.showcase-local"
+CONF_FILE="$OUTPUT_DIR/nginx.conf"
+PORT=8080
+
+echo "serve-showcase: publishing..."
+dotnet publish "$REPO_ROOT/TimeTracker.Client/TimeTracker.Client.csproj" \
+  --configuration Release \
+  -p:Showcase=true \
+  -p:DefineConstants=SHOWCASE \
+  --output "$OUTPUT_DIR" \
+  -v q
+
+cat > "$CONF_FILE" <<'NGINX'
+server {
+    listen 80;
+    location /TimeTracker/ {
+        alias /usr/share/nginx/html/;
+        try_files $uri $uri/ /TimeTracker/index.html;
+    }
+}
+NGINX
+
+echo "serve-showcase: starting nginx on http://localhost:$PORT/TimeTracker/"
+docker run --rm \
+  -p "$PORT:80" \
+  -v "$OUTPUT_DIR/wwwroot:/usr/share/nginx/html:ro" \
+  -v "$CONF_FILE:/etc/nginx/conf.d/default.conf:ro" \
+  nginx:alpine


### PR DESCRIPTION
## Summary

- Adds `scripts/serve-showcase.sh` — publishes the showcase with `SHOWCASE` flags then runs nginx in Docker serving at `http://localhost:8080/TimeTracker/`
- Same URL structure as GitHub Pages so `<base href="/TimeTracker/" />` works without any patching
- SPA fallback configured in nginx so deep links work
- Adds `.showcase-local/` to `.gitignore` (publish output directory)

## Usage

```bash
./scripts/serve-showcase.sh
# open http://localhost:8080/TimeTracker/
```

Requires Docker Desktop running and .NET 10 SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)