### PR TITLE
fix: change auth cookie SameSite from Strict to Lax

### DIFF
--- a/TimeTracker.Web/Program.cs
+++ b/TimeTracker.Web/Program.cs
@@ -48,7 +48,7 @@ builder.Services.ConfigureApplicationCookie(options =>
 {
     options.Cookie.HttpOnly = true;
     options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
-    options.Cookie.SameSite = SameSiteMode.Strict;
+    options.Cookie.SameSite = SameSiteMode.Lax;
     options.LoginPath = "/login";
     options.ExpireTimeSpan = TimeSpan.FromDays(1);
     options.Events.OnRedirectToLogin = context =>


### PR DESCRIPTION
## Summary

- Changes `SameSite=Strict` to `SameSite=Lax` on the ASP.NET Identity application cookie
- Fixes a login loop on iOS Safari when authenticating via Google OAuth

## Root cause

`SameSite=Strict` breaks the OAuth redirect chain on iOS Safari. After Google redirects back to `/auth/callback`, the browser considers the subsequent redirect to `/timeentries` as still part of a cross-site navigation from `accounts.google.com` and withholds the `Strict` cookie. The app sees an unauthenticated request, redirects to `/login`, and the loop begins. Manual page refresh works because it's a fresh same-site navigation.

`Lax` is Microsoft's [documented default](https://learn.microsoft.com/en-us/aspnet/core/security/samesite?view=aspnetcore-10.0) for Cookie Authentication — it allows cookies on top-level cross-site GET navigations (required for OAuth) while still blocking them on cross-site POST/PUT/DELETE (CSRF protection intact).

## Test plan

- [ ] Deploy and log in via Google OAuth on iPhone — confirm no loop
- [ ] Confirm manual refresh still works
- [ ] `dotnet test` — 105 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)