### PR TITLE
chore: mark mockup/ as linguist-vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+mockup/** linguist-vendored


### PR DESCRIPTION
## Summary

Adds `.gitattributes` marking `mockup/` as linguist-vendored. The `mockup/app/data.js` file is a static HTML prototype, not app source code. Without this, GitHub detects JavaScript in the repo and suggests enabling CodeQL JavaScript scanning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)