### PR TITLE
fix: restrict AllowedHosts, add global exception handler, fix Playwright test isolation (#99, #98)

### DIFF
--- a/TimeTracker.Playwright/GlobalSetup.cs
+++ b/TimeTracker.Playwright/GlobalSetup.cs
@@ -3,13 +3,13 @@ using System.Diagnostics;
 namespace TimeTracker.Playwright;
 
 /// <summary>
-/// Runs once before all tests. Starts the app in Release mode (no PDB noise) with
-/// ASPNETCORE_ENVIRONMENT=Development (so /api/dev/login is available), then obtains
-/// a fresh auth session automatically. No manual steps required.
+/// Runs once before all tests. Always starts a fresh app instance on the dedicated
+/// test port (7007) so tests never run against a stale or wrong-version dev instance.
 /// </summary>
 [SetUpFixture]
 public class GlobalSetup
 {
+    private const string TestBaseUrl = "https://localhost:7007";
     private Process? _appProcess;
 
     [OneTimeSetUp]
@@ -17,7 +17,8 @@ public class GlobalSetup
     {
         // WSL sets BROWSER=wslview which Playwright rejects — clear it so Playwright uses chromium
         Environment.SetEnvironmentVariable("BROWSER", null);
-        _appProcess = await StartAppIfNeededAsync();
+        Environment.SetEnvironmentVariable("PLAYWRIGHT_BASE_URL", TestBaseUrl);
+        _appProcess = await StartAppAsync();
         await AuthenticateAsync();
     }
 
@@ -28,17 +29,14 @@ public class GlobalSetup
         _appProcess?.Dispose();
     }
 
-    private static async Task<Process?> StartAppIfNeededAsync()
+    private static async Task<Process> StartAppAsync()
     {
-        if (await IsAppRespondingAsync())
-            return null;
-
         var process = new Process
         {
             StartInfo = new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = "run --configuration Release --launch-profile https",
+                Arguments = $"run --configuration Release --launch-profile https --urls \"{TestBaseUrl}\"",
                 WorkingDirectory = Path.Combine(FindRepoRoot(), "TimeTracker.Web"),
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
@@ -55,7 +53,7 @@ public class GlobalSetup
         using var playwright = await Microsoft.Playwright.Playwright.CreateAsync();
         await using var request = await playwright.APIRequest.NewContextAsync(new()
         {
-            BaseURL = TestConfig.BaseUrl,
+            BaseURL = TestBaseUrl,
             IgnoreHTTPSErrors = true,
         });
 
@@ -68,40 +66,27 @@ public class GlobalSetup
         await request.StorageStateAsync(new() { Path = TestConfig.AuthStatePath });
     }
 
-    private static async Task<bool> IsAppRespondingAsync()
-    {
-        try
-        {
-            using var http = CreateHttpClient(timeout: 3);
-            var r = await http.GetAsync($"{TestConfig.BaseUrl}/login");
-            return r.IsSuccessStatusCode;
-        }
-        catch { return false; }
-    }
-
     private static async Task WaitForAppAsync(int timeoutSeconds)
     {
-        using var http = CreateHttpClient(timeout: 5);
+        using var http = new HttpClient(new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback = (_, _, _, _) => true
+        })
+        { Timeout = TimeSpan.FromSeconds(5) };
+
         var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
         while (DateTime.UtcNow < deadline)
         {
             try
             {
-                var r = await http.GetAsync($"{TestConfig.BaseUrl}/login");
+                var r = await http.GetAsync($"{TestBaseUrl}/login");
                 if (r.IsSuccessStatusCode) return;
             }
             catch { }
             await Task.Delay(1000);
         }
-        throw new TimeoutException($"App did not start within {timeoutSeconds}s at {TestConfig.BaseUrl}");
+        throw new TimeoutException($"App did not start within {timeoutSeconds}s at {TestBaseUrl}");
     }
-
-    private static HttpClient CreateHttpClient(int timeout) =>
-        new(new HttpClientHandler
-        {
-            ServerCertificateCustomValidationCallback = (_, _, _, _) => true
-        })
-        { Timeout = TimeSpan.FromSeconds(timeout) };
 
     private static string FindRepoRoot()
     {

--- a/TimeTracker.Playwright/TestConfig.cs
+++ b/TimeTracker.Playwright/TestConfig.cs
@@ -4,7 +4,7 @@ public static class TestConfig
 {
     public static string BaseUrl =>
         Environment.GetEnvironmentVariable("PLAYWRIGHT_BASE_URL")
-        ?? "https://localhost:7006";
+        ?? "https://localhost:7007";
 
     public static string AuthStatePath =>
         Path.Combine(AppContext.BaseDirectory, "playwright", ".auth", "user.json");

--- a/TimeTracker.Web/Program.cs
+++ b/TimeTracker.Web/Program.cs
@@ -96,6 +96,8 @@ builder.Services.AddRateLimiter(options =>
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
 });
 
+builder.Services.AddProblemDetails();
+
 builder.Services.AddHttpContextAccessor();
 
 // Provide HttpClient for SSR prerender of WASM components that inject it.
@@ -180,6 +182,7 @@ if (app.Environment.IsDevelopment())
     }).RequireAuthorization(adminPolicy);
 }
 
+app.UseExceptionHandler();
 app.UseHsts();
 app.UseHttpsRedirection();
 app.UseMiddleware<SecurityHeadersMiddleware>();

--- a/TimeTracker.Web/appsettings.Development.json
+++ b/TimeTracker.Web/appsettings.Development.json
@@ -9,6 +9,7 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "AllowedHosts": "*",
   "RateLimiting": {
     "AuthStatus": {
       "PermitLimit": 200

--- a/TimeTracker.Web/appsettings.json
+++ b/TimeTracker.Web/appsettings.json
@@ -9,7 +9,7 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*",
+  "AllowedHosts": "timetracker.dzk.com.au;timetracker-zak.azurewebsites.net",
   "RateLimiting": {
     "Auth": {
       "PermitLimit": 10,


### PR DESCRIPTION
## Summary
- Restricts `AllowedHosts` to production hostnames only — closes #99
- Adds `ProblemDetails` service and `UseExceptionHandler` middleware for RFC 7807 Problem Details responses — closes #98
- Fixes Playwright tests to always start a fresh isolated app instance on port 7007, eliminating version drift and port conflicts with the dev instance on 7006
- Adds `AllowedHosts: *` override in `appsettings.Development.json` so localhost requests aren't rejected by the production host filter

## Test plan
- [x] Pre-push hook ran 35/35 Playwright tests (2 write tests skipped as expected)
- [x] 105 unit tests passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)