### PR TITLE
fix: cap connection pool size for Azure SQL free tier (#93)

### DIFF
--- a/TimeTracker.Web/Program.cs
+++ b/TimeTracker.Web/Program.cs
@@ -215,14 +215,18 @@ static string? GetConnectionString(WebApplicationBuilder builder, string connect
     string userCfgName, string passwordCfgName)
 {
     var connectionString = builder.Configuration.GetConnectionString(connectionCfgName);
+    var conStrBuilder = new SqlConnectionStringBuilder(connectionString)
+    {
+        // Azure SQL free tier allows 75 concurrent logins across the logical server.
+        // Two pools × 30 = 60 max connections, leaving headroom for migrations and admin.
+        // MinPoolSize=0 lets connections drain when idle, enabling database auto-pause.
+        MinPoolSize = 0,
+        MaxPoolSize = 30,
+    };
     if (builder.Environment.IsDevelopment())
     {
-        var conStrBuilder = new SqlConnectionStringBuilder(connectionString)
-        {
-            UserID = builder.Configuration[userCfgName],
-            Password = builder.Configuration[passwordCfgName]
-        };
-        connectionString = conStrBuilder.ConnectionString;
+        conStrBuilder.UserID = builder.Configuration[userCfgName];
+        conStrBuilder.Password = builder.Configuration[passwordCfgName];
     }
-    return connectionString;
+    return conStrBuilder.ConnectionString;
 }


### PR DESCRIPTION
## Summary
- Caps `Max Pool Size` at 30 per connection pool (60 total across both pools) to stay within the Azure SQL free tier limit of 75 concurrent logins — closes #93
- Sets `Min Pool Size=0` to allow connections to drain when idle, enabling database auto-pause
- Applied in code via `SqlConnectionStringBuilder` so it takes effect in all environments regardless of what the raw connection string says

## Why in code, not config
Azure App Service connection string settings completely replace `appsettings.json` values in production, so pool settings in config would be silently ignored. Setting them in `GetConnectionString` guarantees they're always applied.

## Test plan
- [x] Pre-push hook: 35/35 Playwright tests passed (2 write tests skipped as expected)
- [x] 105 unit tests passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)