### PR TITLE
feat: global rate limiting covering all API endpoints (#100)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,17 +97,20 @@ jobs:
     if: ${{ needs.check.outputs.code == 'true' }}
 
     steps:
-      - name: Wait for app to warm up
-        run: sleep 20
-
       - name: Assert login page is up
         run: |
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" https://timetracker-zak.azurewebsites.net/login)
-          echo "Login page returned HTTP $HTTP_CODE"
-          if [[ "$HTTP_CODE" != "200" ]]; then
-            echo "Smoke test failed — expected 200, got $HTTP_CODE"
-            exit 1
-          fi
+          for i in {1..5}; do
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" https://timetracker-zak.azurewebsites.net/login)
+            echo "Attempt $i: login page returned HTTP $HTTP_CODE"
+            if [[ "$HTTP_CODE" == "200" ]]; then
+              echo "Smoke test passed"
+              exit 0
+            fi
+            echo "Waiting 15s before retry..."
+            sleep 15
+          done
+          echo "Smoke test failed after 5 attempts — last status $HTTP_CODE"
+          exit 1
 
   showcase:
     name: Deploy Showcase to GitHub Pages

--- a/TimeTracker.Web/Features/Clients/ClientEndpoints.cs
+++ b/TimeTracker.Web/Features/Clients/ClientEndpoints.cs
@@ -24,31 +24,31 @@ public static class ClientEndpoints
         {
             await service.CreateClient(request);
             return Results.Created();
-        });
+        }).RequireRateLimiting("write");
 
         adminGroup.MapPut("/{id:int}", async (int id, ClientUpdateRequest request, IClientService service) =>
         {
             try { await service.UpdateClient(id, request); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }
-        });
+        }).RequireRateLimiting("write");
 
         adminGroup.MapPost("/{id:int}/archive", async (int id, IClientService service) =>
         {
             try { await service.ArchiveClient(id); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }
-        });
+        }).RequireRateLimiting("write");
 
         adminGroup.MapPost("/{id:int}/unarchive", async (int id, IClientService service) =>
         {
             try { await service.UnarchiveClient(id); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }
-        });
+        }).RequireRateLimiting("write");
 
         adminGroup.MapDelete("/{id:int}", async (int id, IClientService service) =>
         {
             try { await service.DeleteClient(id); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }
             catch (InvalidOperationException ex) { return Results.Conflict(ex.Message); }
-        });
+        }).RequireRateLimiting("write");
     }
 }

--- a/TimeTracker.Web/Features/Projects/ProjectEndpoints.cs
+++ b/TimeTracker.Web/Features/Projects/ProjectEndpoints.cs
@@ -24,18 +24,18 @@ public static class ProjectEndpoints
         {
             await svc.CreateProject(request);
             return Results.Created();
-        });
+        }).RequireRateLimiting("write");
 
         adminGroup.MapPut("/{id:int}", async (int id, ProjectUpdateRequest request, IProjectService svc) =>
         {
             try { await svc.UpdateProject(id, request); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }
-        });
+        }).RequireRateLimiting("write");
 
         adminGroup.MapDelete("/{id:int}", async (int id, IProjectService svc) =>
         {
             try { await svc.DeleteProject(id); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }
-        });
+        }).RequireRateLimiting("write");
     }
 }

--- a/TimeTracker.Web/Features/TimeEntries/TimeEntryEndpoints.cs
+++ b/TimeTracker.Web/Features/TimeEntries/TimeEntryEndpoints.cs
@@ -18,7 +18,7 @@ public static class TimeEntryEndpoints
             Results.Ok(await svc.GetTodaysTimeEntries()));
 
         group.MapGet("/year/{year:int}/all", async (int year, ITimeEntryService svc) =>
-            Results.Ok(await svc.GetAllTimeEntriesByYear(year)));
+            Results.Ok(await svc.GetAllTimeEntriesByYear(year))).RequireRateLimiting("all-entries");
 
         group.MapGet("/{skip:int}/{limit:int}", async (int skip, int limit, ITimeEntryQueryService svc) =>
             Results.Ok(await svc.GetTimeEntries(skip, limit)));
@@ -30,7 +30,7 @@ public static class TimeEntryEndpoints
         });
 
         group.MapGet("/project/{projectId:int}/all", async (int projectId, ITimeEntryService svc) =>
-            Results.Ok(await svc.GetAllTimeEntriesByProject(projectId)));
+            Results.Ok(await svc.GetAllTimeEntriesByProject(projectId))).RequireRateLimiting("all-entries");
 
         group.MapGet("/project/{projectId:int}/{skip:int}/{limit:int}", async (int projectId, int skip, int limit, ITimeEntryQueryService svc) =>
             Results.Ok(await svc.GetTimeEntriesByProjectId(projectId, skip, limit)));
@@ -48,18 +48,18 @@ public static class TimeEntryEndpoints
         {
             await svc.CreateTimeEntry(request);
             return Results.Created();
-        });
+        }).RequireRateLimiting("write");
 
         group.MapPut("/{id:int}", async (int id, TimeEntryUpdateRequest request, ITimeEntryService svc) =>
         {
             try { await svc.UpdateTimeEntry(id, request); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }
-        });
+        }).RequireRateLimiting("write");
 
         group.MapDelete("/{id:int}", async (int id, ITimeEntryService svc) =>
         {
             try { await svc.DeleteTimeEntry(id); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }
-        });
+        }).RequireRateLimiting("write");
     }
 }

--- a/TimeTracker.Web/Infrastructure/RateLimitingServiceExtensions.cs
+++ b/TimeTracker.Web/Infrastructure/RateLimitingServiceExtensions.cs
@@ -9,6 +9,33 @@ public static class RateLimitingServiceExtensions
     {
         services.AddRateLimiter(options =>
         {
+            options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(context =>
+                RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: context.User?.Identity?.Name ?? context.Request.Headers.Host.ToString(),
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = configuration.GetValue<int>("RateLimiting:Global:PermitLimit", 120),
+                        Window = TimeSpan.FromMinutes(configuration.GetValue<int>("RateLimiting:Global:WindowMinutes", 1)),
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = 0,
+                    }));
+
+            options.AddFixedWindowLimiter("write", policy =>
+            {
+                policy.PermitLimit = configuration.GetValue<int>("RateLimiting:Write:PermitLimit", 60);
+                policy.Window = TimeSpan.FromMinutes(configuration.GetValue<int>("RateLimiting:Write:WindowMinutes", 1));
+                policy.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
+                policy.QueueLimit = 0;
+            });
+
+            options.AddFixedWindowLimiter("all-entries", policy =>
+            {
+                policy.PermitLimit = configuration.GetValue<int>("RateLimiting:AllEntries:PermitLimit", 10);
+                policy.Window = TimeSpan.FromMinutes(configuration.GetValue<int>("RateLimiting:AllEntries:WindowMinutes", 1));
+                policy.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
+                policy.QueueLimit = 0;
+            });
+
             options.AddFixedWindowLimiter("auth", policy =>
             {
                 policy.PermitLimit = configuration.GetValue<int>("RateLimiting:Auth:PermitLimit", 10);
@@ -16,6 +43,7 @@ public static class RateLimitingServiceExtensions
                 policy.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
                 policy.QueueLimit = 0;
             });
+
             options.AddFixedWindowLimiter("auth-status", policy =>
             {
                 policy.PermitLimit = configuration.GetValue<int>("RateLimiting:AuthStatus:PermitLimit", 10);
@@ -23,6 +51,7 @@ public static class RateLimitingServiceExtensions
                 policy.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
                 policy.QueueLimit = 0;
             });
+
             options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
         });
 

--- a/TimeTracker.Web/appsettings.Development.json
+++ b/TimeTracker.Web/appsettings.Development.json
@@ -11,6 +11,12 @@
   },
   "AllowedHosts": "*",
   "RateLimiting": {
+    "Global": {
+      "PermitLimit": 10000
+    },
+    "AllEntries": {
+      "PermitLimit": 10000
+    },
     "AuthStatus": {
       "PermitLimit": 200
     }

--- a/TimeTracker.Web/appsettings.json
+++ b/TimeTracker.Web/appsettings.json
@@ -11,6 +11,18 @@
   },
   "AllowedHosts": "timetracker.dzk.com.au;timetracker-zak.azurewebsites.net",
   "RateLimiting": {
+    "Global": {
+      "PermitLimit": 120,
+      "WindowMinutes": 1
+    },
+    "Write": {
+      "PermitLimit": 60,
+      "WindowMinutes": 1
+    },
+    "AllEntries": {
+      "PermitLimit": 10,
+      "WindowMinutes": 1
+    },
     "Auth": {
       "PermitLimit": 10,
       "WindowMinutes": 1


### PR DESCRIPTION
## Summary
- Global default policy (120/min) covers all endpoints automatically — new endpoints get protection for free
- `"write"` policy (60/min) applied explicitly to all POST/PUT/DELETE endpoints across TimeEntries, Projects, Clients
- `"all-entries"` policy (10/min) applied explicitly to unbounded `/year/{year}/all` and `/project/{id}/all` endpoints
- All limits config-driven via `appsettings.json`; dev overrides in `appsettings.Development.json` prevent test throttling
- Smoke test retry loop (5 attempts × 15s) replaces fixed 20s sleep — handles Azure SQL wakeup delay without blocking fast deploys

## Why dev overrides are needed
The global rate limiter intercepts all requests including WASM framework file downloads via `MapStaticAssets`. Each Playwright page load triggers 30+ requests sharing a single host-based partition key, exhausting the 120/min default mid-suite. `Global` and `AllEntries` are set to 10,000/min in dev (matching the existing `AuthStatus` pattern).

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test TimeTracker.Tests` — 106/106 passed
- [x] Playwright pre-push hook — 35/35 passed, 2 write tests skipped

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)