### PR TITLE
feat: thread CancellationToken through all service methods and EF Core calls (#115)

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,24 +1,23 @@
 # Session handoff — 2026-06-14
 
 ## Current state
-- Branch: `main`, clean (PR #113 open — SESSION.md chore, merge when ready)
-- All high priority issues complete (PRs #109, #110, #112, issue #105 closed)
-- All CI green
+- Branch: `main`, clean
+- PRs #114 (#111), #117 (#116), #118 (#100) all merged this session
+- New issues created: #115 (cancellation tokens), #116 (pagination cap)
 
-## Plan — medium priority (work next)
+## Completed this session
+- ✅ #111 Program.cs refactor (PR #114)
+- ✅ #116 Server-side pagination cap + timer dispose fix (PR #117)
+- ✅ #100 Global rate limiting covering all endpoints (PR #118)
+- ✅ D018 added to decisions.md, architecture.md updated
 
-Work in order, one branch per item:
+## Plan — remaining medium priority (work in order)
 
-### Step 1 — Program.cs refactor
-- **#111** 🟡 Extract service registrations and dev endpoints into extension methods
-  - `AddApplicationAuth()` — auth/cookie/Google registration
-  - `AddApplicationRateLimiting()` — rate limiter registration
-  - `MapDevEndpoints()` — `/api/dev/login`, `/api/dev/seed`, `/api/dev/clear`
-  - Move `GetConnectionString` into `Infrastructure/` class
-  - Target: Program.cs ~50 lines
-
-### Step 2 — Rate limiting
-- **#100** 🟡 Add rate limiting to all mutating API endpoints (ASP.NET Core built-in RateLimiter)
+### Next up — Step C (before moving on)
+- **#115** 🟢 Cancellation tokens — thread `CancellationToken` through all service methods and EF Core calls
+  - All service interfaces + implementations (TimeEntries, Projects, Clients, Auth)
+  - All EF Core async calls (`ToListAsync`, `FirstOrDefaultAsync`, `SaveChangesAsync`, etc.)
+  - Largest refactor of the defence-in-depth batch; do before Step 3
 
 ### Step 3 — Session revocation
 - **#103** 🟡 Session revocation via SecurityStamp
@@ -34,6 +33,7 @@ Work in order, one branch per item:
 - **#95** 🟢 Database-backed user management
 - **#96** 🟢 Staging environment (requires paid tier upgrade)
 - **#102** 🟢 Email/password fallback + TOTP MFA
+- **#115** 🟢 Cancellation tokens (defence-in-depth, Step C)
 
 ## Active tech debt (genuine constraints, no action until paid tier)
 | # | Item | ADR |
@@ -53,4 +53,4 @@ cat SESSION.md
 ```
 
 ---
-*Updated 2026-06-14. Next: Step 1 — #111 Program.cs refactor.*
+*Updated 2026-06-14. Next: #115 cancellation tokens (Step C), then Step 3 session revocation.*

--- a/TimeTracker.Client/Features/Clients/HttpClientService.cs
+++ b/TimeTracker.Client/Features/Clients/HttpClientService.cs
@@ -5,39 +5,39 @@ namespace TimeTracker.Client.Features.Clients;
 
 public class HttpClientService(HttpClient http) : IClientService
 {
-    public Task<List<ClientResponse>> GetAllClients(bool includeArchived = false) =>
-        http.GetFromJsonAsync<List<ClientResponse>>($"api/clients/?includeArchived={includeArchived}")!;
+    public Task<List<ClientResponse>> GetAllClients(bool includeArchived = false, CancellationToken ct = default) =>
+        http.GetFromJsonAsync<List<ClientResponse>>($"api/clients/?includeArchived={includeArchived}", ct)!;
 
-    public Task<ClientResponse?> GetClientById(int id) =>
-        http.GetFromJsonAsync<ClientResponse>($"api/clients/{id}");
+    public Task<ClientResponse?> GetClientById(int id, CancellationToken ct = default) =>
+        http.GetFromJsonAsync<ClientResponse>($"api/clients/{id}", ct);
 
-    public async Task CreateClient(ClientCreateRequest request)
+    public async Task CreateClient(ClientCreateRequest request, CancellationToken ct = default)
     {
-        var response = await http.PostAsJsonAsync("api/clients/", request);
+        var response = await http.PostAsJsonAsync("api/clients/", request, ct);
         response.EnsureSuccessStatusCode();
     }
 
-    public async Task UpdateClient(int id, ClientUpdateRequest request)
+    public async Task UpdateClient(int id, ClientUpdateRequest request, CancellationToken ct = default)
     {
-        var response = await http.PutAsJsonAsync($"api/clients/{id}", request);
+        var response = await http.PutAsJsonAsync($"api/clients/{id}", request, ct);
         response.EnsureSuccessStatusCode();
     }
 
-    public async Task ArchiveClient(int id)
+    public async Task ArchiveClient(int id, CancellationToken ct = default)
     {
-        var response = await http.PostAsync($"api/clients/{id}/archive", null);
+        var response = await http.PostAsync($"api/clients/{id}/archive", null, ct);
         response.EnsureSuccessStatusCode();
     }
 
-    public async Task UnarchiveClient(int id)
+    public async Task UnarchiveClient(int id, CancellationToken ct = default)
     {
-        var response = await http.PostAsync($"api/clients/{id}/unarchive", null);
+        var response = await http.PostAsync($"api/clients/{id}/unarchive", null, ct);
         response.EnsureSuccessStatusCode();
     }
 
-    public async Task DeleteClient(int id)
+    public async Task DeleteClient(int id, CancellationToken ct = default)
     {
-        var response = await http.DeleteAsync($"api/clients/{id}");
+        var response = await http.DeleteAsync($"api/clients/{id}", ct);
         response.EnsureSuccessStatusCode();
     }
 }

--- a/TimeTracker.Client/Features/Projects/HttpProjectService.cs
+++ b/TimeTracker.Client/Features/Projects/HttpProjectService.cs
@@ -5,27 +5,27 @@ namespace TimeTracker.Client.Features.Projects;
 
 public class HttpProjectService(HttpClient http) : IProjectService
 {
-    public Task<List<ProjectResponse>> GetAllProjects() =>
-        http.GetFromJsonAsync<List<ProjectResponse>>("api/projects/")!;
+    public Task<List<ProjectResponse>> GetAllProjects(CancellationToken ct = default) =>
+        http.GetFromJsonAsync<List<ProjectResponse>>("api/projects/", ct)!;
 
-    public Task<ProjectResponse?> GetProjectById(int id) =>
-        http.GetFromJsonAsync<ProjectResponse>($"api/projects/{id}");
+    public Task<ProjectResponse?> GetProjectById(int id, CancellationToken ct = default) =>
+        http.GetFromJsonAsync<ProjectResponse>($"api/projects/{id}", ct);
 
-    public async Task CreateProject(ProjectCreateRequest request)
+    public async Task CreateProject(ProjectCreateRequest request, CancellationToken ct = default)
     {
-        var response = await http.PostAsJsonAsync("api/projects/", request);
+        var response = await http.PostAsJsonAsync("api/projects/", request, ct);
         response.EnsureSuccessStatusCode();
     }
 
-    public async Task UpdateProject(int id, ProjectUpdateRequest request)
+    public async Task UpdateProject(int id, ProjectUpdateRequest request, CancellationToken ct = default)
     {
-        var response = await http.PutAsJsonAsync($"api/projects/{id}", request);
+        var response = await http.PutAsJsonAsync($"api/projects/{id}", request, ct);
         response.EnsureSuccessStatusCode();
     }
 
-    public async Task DeleteProject(int id)
+    public async Task DeleteProject(int id, CancellationToken ct = default)
     {
-        var response = await http.DeleteAsync($"api/projects/{id}");
+        var response = await http.DeleteAsync($"api/projects/{id}", ct);
         response.EnsureSuccessStatusCode();
     }
 }

--- a/TimeTracker.Client/Features/TimeEntries/HttpTimeEntryService.cs
+++ b/TimeTracker.Client/Features/TimeEntries/HttpTimeEntryService.cs
@@ -6,41 +6,41 @@ namespace TimeTracker.Client.Features.TimeEntries;
 
 public class HttpTimeEntryService(HttpClient http) : ITimeEntryService
 {
-    public async Task<TimeEntryResponse?> GetActiveTimeEntry()
+    public async Task<TimeEntryResponse?> GetActiveTimeEntry(CancellationToken ct = default)
     {
-        var response = await http.GetAsync("api/timeentries/active");
+        var response = await http.GetAsync("api/timeentries/active", ct);
         if (response.StatusCode == HttpStatusCode.NoContent) return null;
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<TimeEntryResponse>();
+        return await response.Content.ReadFromJsonAsync<TimeEntryResponse>(ct);
     }
 
-    public Task<List<TimeEntryResponse>> GetTodaysTimeEntries() =>
-        http.GetFromJsonAsync<List<TimeEntryResponse>>("api/timeentries/today")!;
+    public Task<List<TimeEntryResponse>> GetTodaysTimeEntries(CancellationToken ct = default) =>
+        http.GetFromJsonAsync<List<TimeEntryResponse>>("api/timeentries/today", ct)!;
 
-    public Task<List<TimeEntryResponse>> GetAllTimeEntriesByYear(int year) =>
-        http.GetFromJsonAsync<List<TimeEntryResponse>>($"api/timeentries/year/{year}/all")!;
+    public Task<List<TimeEntryResponse>> GetAllTimeEntriesByYear(int year, CancellationToken ct = default) =>
+        http.GetFromJsonAsync<List<TimeEntryResponse>>($"api/timeentries/year/{year}/all", ct)!;
 
-    public async Task CreateTimeEntry(TimeEntryCreateRequest request)
+    public async Task CreateTimeEntry(TimeEntryCreateRequest request, CancellationToken ct = default)
     {
-        var response = await http.PostAsJsonAsync("api/timeentries/", request);
+        var response = await http.PostAsJsonAsync("api/timeentries/", request, ct);
         response.EnsureSuccessStatusCode();
     }
 
-    public async Task UpdateTimeEntry(int id, TimeEntryUpdateRequest request)
+    public async Task UpdateTimeEntry(int id, TimeEntryUpdateRequest request, CancellationToken ct = default)
     {
-        var response = await http.PutAsJsonAsync($"api/timeentries/{id}", request);
+        var response = await http.PutAsJsonAsync($"api/timeentries/{id}", request, ct);
         response.EnsureSuccessStatusCode();
     }
 
-    public async Task DeleteTimeEntry(int id)
+    public async Task DeleteTimeEntry(int id, CancellationToken ct = default)
     {
-        var response = await http.DeleteAsync($"api/timeentries/{id}");
+        var response = await http.DeleteAsync($"api/timeentries/{id}", ct);
         response.EnsureSuccessStatusCode();
     }
 
-    public Task<TimeEntryResponse?> GetTimeEntryById(int id) =>
-        http.GetFromJsonAsync<TimeEntryResponse>($"api/timeentries/{id}");
+    public Task<TimeEntryResponse?> GetTimeEntryById(int id, CancellationToken ct = default) =>
+        http.GetFromJsonAsync<TimeEntryResponse>($"api/timeentries/{id}", ct);
 
-    public Task<List<TimeEntryResponse>> GetAllTimeEntriesByProject(int projectId) =>
-        http.GetFromJsonAsync<List<TimeEntryResponse>>($"api/timeentries/project/{projectId}/all")!;
+    public Task<List<TimeEntryResponse>> GetAllTimeEntriesByProject(int projectId, CancellationToken ct = default) =>
+        http.GetFromJsonAsync<List<TimeEntryResponse>>($"api/timeentries/project/{projectId}/all", ct)!;
 }

--- a/TimeTracker.Client/Mock/MockClientService.cs
+++ b/TimeTracker.Client/Mock/MockClientService.cs
@@ -4,15 +4,15 @@ namespace TimeTracker.Client.Mock;
 
 public class MockClientService(MockDataStore store) : IClientService
 {
-    public Task<List<ClientResponse>> GetAllClients(bool includeArchived = false) =>
+    public Task<List<ClientResponse>> GetAllClients(bool includeArchived = false, CancellationToken ct = default) =>
         Task.FromResult(store.Clients
             .Where(c => includeArchived || !c.IsArchived)
             .ToList());
 
-    public Task<ClientResponse?> GetClientById(int id) =>
+    public Task<ClientResponse?> GetClientById(int id, CancellationToken ct = default) =>
         Task.FromResult(store.Clients.FirstOrDefault(c => c.Id == id));
 
-    public Task CreateClient(ClientCreateRequest request)
+    public Task CreateClient(ClientCreateRequest request, CancellationToken ct = default)
     {
         store.Clients.Add(new ClientResponse(
             store.NextClientId(),
@@ -25,7 +25,7 @@ public class MockClientService(MockDataStore store) : IClientService
         return Task.CompletedTask;
     }
 
-    public Task UpdateClient(int id, ClientUpdateRequest request)
+    public Task UpdateClient(int id, ClientUpdateRequest request, CancellationToken ct = default)
     {
         var i = store.Clients.FindIndex(c => c.Id == id);
         if (i < 0) return Task.CompletedTask;
@@ -42,21 +42,21 @@ public class MockClientService(MockDataStore store) : IClientService
         return Task.CompletedTask;
     }
 
-    public Task ArchiveClient(int id)
+    public Task ArchiveClient(int id, CancellationToken ct = default)
     {
         var i = store.Clients.FindIndex(c => c.Id == id);
         if (i >= 0) store.Clients[i] = store.Clients[i] with { IsArchived = true };
         return Task.CompletedTask;
     }
 
-    public Task UnarchiveClient(int id)
+    public Task UnarchiveClient(int id, CancellationToken ct = default)
     {
         var i = store.Clients.FindIndex(c => c.Id == id);
         if (i >= 0) store.Clients[i] = store.Clients[i] with { IsArchived = false };
         return Task.CompletedTask;
     }
 
-    public Task DeleteClient(int id)
+    public Task DeleteClient(int id, CancellationToken ct = default)
     {
         store.Clients.RemoveAll(c => c.Id == id);
         return Task.CompletedTask;

--- a/TimeTracker.Client/Mock/MockProjectService.cs
+++ b/TimeTracker.Client/Mock/MockProjectService.cs
@@ -4,13 +4,13 @@ namespace TimeTracker.Client.Mock;
 
 public class MockProjectService(MockDataStore store) : IProjectService
 {
-    public Task<List<ProjectResponse>> GetAllProjects() =>
+    public Task<List<ProjectResponse>> GetAllProjects(CancellationToken ct = default) =>
         Task.FromResult(store.Projects.ToList());
 
-    public Task<ProjectResponse?> GetProjectById(int id) =>
+    public Task<ProjectResponse?> GetProjectById(int id, CancellationToken ct = default) =>
         Task.FromResult(store.Projects.FirstOrDefault(p => p.Id == id));
 
-    public Task CreateProject(ProjectCreateRequest request)
+    public Task CreateProject(ProjectCreateRequest request, CancellationToken ct = default)
     {
         var client = request.ClientId.HasValue
             ? store.Clients.FirstOrDefault(c => c.Id == request.ClientId.Value)
@@ -27,7 +27,7 @@ public class MockProjectService(MockDataStore store) : IProjectService
         return Task.CompletedTask;
     }
 
-    public Task UpdateProject(int id, ProjectUpdateRequest request)
+    public Task UpdateProject(int id, ProjectUpdateRequest request, CancellationToken ct = default)
     {
         var i = store.Projects.FindIndex(p => p.Id == id);
         if (i < 0) return Task.CompletedTask;
@@ -48,7 +48,7 @@ public class MockProjectService(MockDataStore store) : IProjectService
         return Task.CompletedTask;
     }
 
-    public Task DeleteProject(int id)
+    public Task DeleteProject(int id, CancellationToken ct = default)
     {
         store.Projects.RemoveAll(p => p.Id == id);
         return Task.CompletedTask;

--- a/TimeTracker.Client/Mock/MockTimeEntryService.cs
+++ b/TimeTracker.Client/Mock/MockTimeEntryService.cs
@@ -5,31 +5,31 @@ namespace TimeTracker.Client.Mock;
 
 public class MockTimeEntryService(MockDataStore store) : ITimeEntryService
 {
-    public Task<TimeEntryResponse?> GetActiveTimeEntry() =>
+    public Task<TimeEntryResponse?> GetActiveTimeEntry(CancellationToken ct = default) =>
         Task.FromResult(store.TimeEntries.FirstOrDefault(e => !e.End.HasValue));
 
-    public Task<List<TimeEntryResponse>> GetTodaysTimeEntries() =>
+    public Task<List<TimeEntryResponse>> GetTodaysTimeEntries(CancellationToken ct = default) =>
         Task.FromResult(store.TimeEntries
             .Where(e => e.Start.Date == DateTime.Today)
             .OrderByDescending(e => e.Start)
             .ToList());
 
-    public Task<List<TimeEntryResponse>> GetAllTimeEntriesByYear(int year) =>
+    public Task<List<TimeEntryResponse>> GetAllTimeEntriesByYear(int year, CancellationToken ct = default) =>
         Task.FromResult(store.TimeEntries
             .Where(e => e.Start.Year == year)
             .OrderByDescending(e => e.Start)
             .ToList());
 
-    public Task<List<TimeEntryResponse>> GetAllTimeEntriesByProject(int projectId) =>
+    public Task<List<TimeEntryResponse>> GetAllTimeEntriesByProject(int projectId, CancellationToken ct = default) =>
         Task.FromResult(store.TimeEntries
             .Where(e => e.Project.Id == projectId)
             .OrderByDescending(e => e.Start)
             .ToList());
 
-    public Task<TimeEntryResponse?> GetTimeEntryById(int id) =>
+    public Task<TimeEntryResponse?> GetTimeEntryById(int id, CancellationToken ct = default) =>
         Task.FromResult(store.TimeEntries.FirstOrDefault(e => e.Id == id));
 
-    public Task CreateTimeEntry(TimeEntryCreateRequest request)
+    public Task CreateTimeEntry(TimeEntryCreateRequest request, CancellationToken ct = default)
     {
         var project = store.Projects.First(p => p.Id == request.ProjectId);
         store.TimeEntries.Add(new TimeEntryResponse(
@@ -43,7 +43,7 @@ public class MockTimeEntryService(MockDataStore store) : ITimeEntryService
         return Task.CompletedTask;
     }
 
-    public Task UpdateTimeEntry(int id, TimeEntryUpdateRequest request)
+    public Task UpdateTimeEntry(int id, TimeEntryUpdateRequest request, CancellationToken ct = default)
     {
         var i = store.TimeEntries.FindIndex(e => e.Id == id);
         if (i < 0) return Task.CompletedTask;
@@ -64,7 +64,7 @@ public class MockTimeEntryService(MockDataStore store) : ITimeEntryService
         return Task.CompletedTask;
     }
 
-    public Task DeleteTimeEntry(int id)
+    public Task DeleteTimeEntry(int id, CancellationToken ct = default)
     {
         store.TimeEntries.RemoveAll(e => e.Id == id);
         return Task.CompletedTask;

--- a/TimeTracker.Contracts/Features/Clients/IClientService.cs
+++ b/TimeTracker.Contracts/Features/Clients/IClientService.cs
@@ -2,11 +2,11 @@ namespace TimeTracker.Contracts.Features.Clients;
 
 public interface IClientService
 {
-    Task<List<ClientResponse>> GetAllClients(bool includeArchived = false);
-    Task<ClientResponse?> GetClientById(int id);
-    Task CreateClient(ClientCreateRequest request);
-    Task UpdateClient(int id, ClientUpdateRequest request);
-    Task ArchiveClient(int id);
-    Task UnarchiveClient(int id);
-    Task DeleteClient(int id);
+    Task<List<ClientResponse>> GetAllClients(bool includeArchived = false, CancellationToken ct = default);
+    Task<ClientResponse?> GetClientById(int id, CancellationToken ct = default);
+    Task CreateClient(ClientCreateRequest request, CancellationToken ct = default);
+    Task UpdateClient(int id, ClientUpdateRequest request, CancellationToken ct = default);
+    Task ArchiveClient(int id, CancellationToken ct = default);
+    Task UnarchiveClient(int id, CancellationToken ct = default);
+    Task DeleteClient(int id, CancellationToken ct = default);
 }

--- a/TimeTracker.Contracts/Features/Projects/IProjectService.cs
+++ b/TimeTracker.Contracts/Features/Projects/IProjectService.cs
@@ -2,9 +2,9 @@ namespace TimeTracker.Contracts.Features.Projects;
 
 public interface IProjectService
 {
-    Task<List<ProjectResponse>> GetAllProjects();
-    Task<ProjectResponse?> GetProjectById(int id);
-    Task CreateProject(ProjectCreateRequest request);
-    Task UpdateProject(int id, ProjectUpdateRequest request);
-    Task DeleteProject(int id);
+    Task<List<ProjectResponse>> GetAllProjects(CancellationToken ct = default);
+    Task<ProjectResponse?> GetProjectById(int id, CancellationToken ct = default);
+    Task CreateProject(ProjectCreateRequest request, CancellationToken ct = default);
+    Task UpdateProject(int id, ProjectUpdateRequest request, CancellationToken ct = default);
+    Task DeleteProject(int id, CancellationToken ct = default);
 }

--- a/TimeTracker.Contracts/Features/TimeEntries/ITimeEntryQueryService.cs
+++ b/TimeTracker.Contracts/Features/TimeEntries/ITimeEntryQueryService.cs
@@ -2,9 +2,9 @@ namespace TimeTracker.Contracts.Features.TimeEntries;
 
 public interface ITimeEntryQueryService
 {
-    Task<TimeEntryResponseWrapper> GetTimeEntries(int skip, int limit);
-    Task<TimeEntryResponseWrapper> GetTimeEntriesByProjectId(int projectId, int skip, int limit);
-    Task<TimeEntryResponseWrapper> GetTimeEntriesByYear(int year, int skip, int limit);
-    Task<TimeEntryResponseWrapper> GetTimeEntriesByMonth(int month, int year, int skip, int limit);
-    Task<TimeEntryResponseWrapper> GetTimeEntriesByDay(int day, int month, int year, int skip, int limit);
+    Task<TimeEntryResponseWrapper> GetTimeEntries(int skip, int limit, CancellationToken ct = default);
+    Task<TimeEntryResponseWrapper> GetTimeEntriesByProjectId(int projectId, int skip, int limit, CancellationToken ct = default);
+    Task<TimeEntryResponseWrapper> GetTimeEntriesByYear(int year, int skip, int limit, CancellationToken ct = default);
+    Task<TimeEntryResponseWrapper> GetTimeEntriesByMonth(int month, int year, int skip, int limit, CancellationToken ct = default);
+    Task<TimeEntryResponseWrapper> GetTimeEntriesByDay(int day, int month, int year, int skip, int limit, CancellationToken ct = default);
 }

--- a/TimeTracker.Contracts/Features/TimeEntries/ITimeEntryService.cs
+++ b/TimeTracker.Contracts/Features/TimeEntries/ITimeEntryService.cs
@@ -2,12 +2,12 @@ namespace TimeTracker.Contracts.Features.TimeEntries;
 
 public interface ITimeEntryService
 {
-    Task<TimeEntryResponse?> GetTimeEntryById(int id);
-    Task CreateTimeEntry(TimeEntryCreateRequest request);
-    Task UpdateTimeEntry(int id, TimeEntryUpdateRequest request);
-    Task DeleteTimeEntry(int id);
-    Task<List<TimeEntryResponse>> GetAllTimeEntriesByYear(int year);
-    Task<TimeEntryResponse?> GetActiveTimeEntry();
-    Task<List<TimeEntryResponse>> GetTodaysTimeEntries();
-    Task<List<TimeEntryResponse>> GetAllTimeEntriesByProject(int projectId);
+    Task<TimeEntryResponse?> GetTimeEntryById(int id, CancellationToken ct = default);
+    Task CreateTimeEntry(TimeEntryCreateRequest request, CancellationToken ct = default);
+    Task UpdateTimeEntry(int id, TimeEntryUpdateRequest request, CancellationToken ct = default);
+    Task DeleteTimeEntry(int id, CancellationToken ct = default);
+    Task<List<TimeEntryResponse>> GetAllTimeEntriesByYear(int year, CancellationToken ct = default);
+    Task<TimeEntryResponse?> GetActiveTimeEntry(CancellationToken ct = default);
+    Task<List<TimeEntryResponse>> GetTodaysTimeEntries(CancellationToken ct = default);
+    Task<List<TimeEntryResponse>> GetAllTimeEntriesByProject(int projectId, CancellationToken ct = default);
 }

--- a/TimeTracker.Tests/Features/Clients/ClientEndpointAuthTests.cs
+++ b/TimeTracker.Tests/Features/Clients/ClientEndpointAuthTests.cs
@@ -67,12 +67,12 @@ public class ClientEndpointAuthTests
 
     private sealed class StubClientService : IClientService
     {
-        public Task<List<ClientResponse>> GetAllClients(bool includeArchived = false) => Task.FromResult(new List<ClientResponse>());
-        public Task<ClientResponse?> GetClientById(int id) => Task.FromResult<ClientResponse?>(null);
-        public Task CreateClient(ClientCreateRequest request) => Task.CompletedTask;
-        public Task UpdateClient(int id, ClientUpdateRequest request) => Task.CompletedTask;
-        public Task ArchiveClient(int id) => Task.CompletedTask;
-        public Task UnarchiveClient(int id) => Task.CompletedTask;
-        public Task DeleteClient(int id) => Task.CompletedTask;
+        public Task<List<ClientResponse>> GetAllClients(bool includeArchived = false, CancellationToken ct = default) => Task.FromResult(new List<ClientResponse>());
+        public Task<ClientResponse?> GetClientById(int id, CancellationToken ct = default) => Task.FromResult<ClientResponse?>(null);
+        public Task CreateClient(ClientCreateRequest request, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UpdateClient(int id, ClientUpdateRequest request, CancellationToken ct = default) => Task.CompletedTask;
+        public Task ArchiveClient(int id, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UnarchiveClient(int id, CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeleteClient(int id, CancellationToken ct = default) => Task.CompletedTask;
     }
 }

--- a/TimeTracker.Tests/Features/Projects/ProjectEndpointAuthTests.cs
+++ b/TimeTracker.Tests/Features/Projects/ProjectEndpointAuthTests.cs
@@ -66,10 +66,10 @@ public class ProjectEndpointAuthTests
 
     private sealed class StubProjectService : IProjectService
     {
-        public Task<List<ProjectResponse>> GetAllProjects() => Task.FromResult(new List<ProjectResponse>());
-        public Task<ProjectResponse?> GetProjectById(int id) => Task.FromResult<ProjectResponse?>(null);
-        public Task CreateProject(ProjectCreateRequest request) => Task.CompletedTask;
-        public Task UpdateProject(int id, ProjectUpdateRequest request) => Task.CompletedTask;
-        public Task DeleteProject(int id) => Task.CompletedTask;
+        public Task<List<ProjectResponse>> GetAllProjects(CancellationToken ct = default) => Task.FromResult(new List<ProjectResponse>());
+        public Task<ProjectResponse?> GetProjectById(int id, CancellationToken ct = default) => Task.FromResult<ProjectResponse?>(null);
+        public Task CreateProject(ProjectCreateRequest request, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UpdateProject(int id, ProjectUpdateRequest request, CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeleteProject(int id, CancellationToken ct = default) => Task.CompletedTask;
     }
 }

--- a/TimeTracker.Web/Features/Clients/ClientEndpoints.cs
+++ b/TimeTracker.Web/Features/Clients/ClientEndpoints.cs
@@ -11,42 +11,42 @@ public static class ClientEndpoints
         var adminGroup = app.MapGroup("/api/clients").RequireAuthorization(
             new AuthorizationPolicyBuilder().RequireAuthenticatedUser().RequireRole("Admin").Build());
 
-        group.MapGet("/", async (IClientService service, bool includeArchived = false) =>
-            Results.Ok(await service.GetAllClients(includeArchived)));
+        group.MapGet("/", async (IClientService service, bool includeArchived, CancellationToken ct) =>
+            Results.Ok(await service.GetAllClients(includeArchived, ct)));
 
-        group.MapGet("/{id:int}", async (int id, IClientService service) =>
+        group.MapGet("/{id:int}", async (int id, IClientService service, CancellationToken ct) =>
         {
-            var client = await service.GetClientById(id);
+            var client = await service.GetClientById(id, ct);
             return client is null ? Results.NotFound() : Results.Ok(client);
         });
 
-        adminGroup.MapPost("/", async (ClientCreateRequest request, IClientService service) =>
+        adminGroup.MapPost("/", async (ClientCreateRequest request, IClientService service, CancellationToken ct) =>
         {
-            await service.CreateClient(request);
+            await service.CreateClient(request, ct);
             return Results.Created();
         }).RequireRateLimiting("write");
 
-        adminGroup.MapPut("/{id:int}", async (int id, ClientUpdateRequest request, IClientService service) =>
+        adminGroup.MapPut("/{id:int}", async (int id, ClientUpdateRequest request, IClientService service, CancellationToken ct) =>
         {
-            try { await service.UpdateClient(id, request); return Results.NoContent(); }
+            try { await service.UpdateClient(id, request, ct); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }
         }).RequireRateLimiting("write");
 
-        adminGroup.MapPost("/{id:int}/archive", async (int id, IClientService service) =>
+        adminGroup.MapPost("/{id:int}/archive", async (int id, IClientService service, CancellationToken ct) =>
         {
-            try { await service.ArchiveClient(id); return Results.NoContent(); }
+            try { await service.ArchiveClient(id, ct); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }
         }).RequireRateLimiting("write");
 
-        adminGroup.MapPost("/{id:int}/unarchive", async (int id, IClientService service) =>
+        adminGroup.MapPost("/{id:int}/unarchive", async (int id, IClientService service, CancellationToken ct) =>
         {
-            try { await service.UnarchiveClient(id); return Results.NoContent(); }
+            try { await service.UnarchiveClient(id, ct); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }
         }).RequireRateLimiting("write");
 
-        adminGroup.MapDelete("/{id:int}", async (int id, IClientService service) =>
+        adminGroup.MapDelete("/{id:int}", async (int id, IClientService service, CancellationToken ct) =>
         {
-            try { await service.DeleteClient(id); return Results.NoContent(); }
+            try { await service.DeleteClient(id, ct); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }
             catch (InvalidOperationException ex) { return Results.Conflict(ex.Message); }
         }).RequireRateLimiting("write");

--- a/TimeTracker.Web/Features/Clients/ClientService.cs
+++ b/TimeTracker.Web/Features/Clients/ClientService.cs
@@ -15,27 +15,27 @@ public class ClientService : IClientService
         _contextFactory = contextFactory;
     }
 
-    public async Task<List<ClientResponse>> GetAllClients(bool includeArchived = false)
+    public async Task<List<ClientResponse>> GetAllClients(bool includeArchived = false, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
         var query = ctx.Clients
             .Where(c => !c.IsDeleted)
             .Where(c => includeArchived || !c.IsArchived)
             .OrderBy(c => c.IsArchived)
             .ThenBy(c => c.Name);
-        return (await query.ToListAsync()).Adapt<List<ClientResponse>>();
+        return (await query.ToListAsync(ct)).Adapt<List<ClientResponse>>();
     }
 
-    public async Task<ClientResponse?> GetClientById(int id)
+    public async Task<ClientResponse?> GetClientById(int id, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
-        var client = await ctx.Clients.FirstOrDefaultAsync(c => c.Id == id && !c.IsDeleted);
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
+        var client = await ctx.Clients.FirstOrDefaultAsync(c => c.Id == id && !c.IsDeleted, ct);
         return client?.Adapt<ClientResponse>();
     }
 
-    public async Task CreateClient(ClientCreateRequest request)
+    public async Task CreateClient(ClientCreateRequest request, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
         var client = new TimeTracker.Shared.Entities.Client
         {
             Name = request.Name,
@@ -45,13 +45,13 @@ public class ClientService : IClientService
             ContactPhone = request.ContactPhone
         };
         ctx.Clients.Add(client);
-        await ctx.SaveChangesAsync();
+        await ctx.SaveChangesAsync(ct);
     }
 
-    public async Task UpdateClient(int id, ClientUpdateRequest request)
+    public async Task UpdateClient(int id, ClientUpdateRequest request, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
-        var client = await ctx.Clients.FindAsync(id)
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
+        var client = await ctx.Clients.FindAsync([id], ct)
             ?? throw new EntityNotFoundException($"Client {id} not found.");
 
         client.Name = request.Name;
@@ -60,43 +60,43 @@ public class ClientService : IClientService
         client.ContactEmail = request.ContactEmail;
         client.ContactPhone = request.ContactPhone;
         client.DateUpdated = DateTime.Now;
-        await ctx.SaveChangesAsync();
+        await ctx.SaveChangesAsync(ct);
     }
 
-    public async Task ArchiveClient(int id)
+    public async Task ArchiveClient(int id, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
-        var client = await ctx.Clients.FirstOrDefaultAsync(c => c.Id == id && !c.IsDeleted)
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
+        var client = await ctx.Clients.FirstOrDefaultAsync(c => c.Id == id && !c.IsDeleted, ct)
             ?? throw new EntityNotFoundException($"Client {id} not found.");
 
         client.IsArchived = true;
         client.DateUpdated = DateTime.Now;
-        await ctx.SaveChangesAsync();
+        await ctx.SaveChangesAsync(ct);
     }
 
-    public async Task UnarchiveClient(int id)
+    public async Task UnarchiveClient(int id, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
-        var client = await ctx.Clients.FirstOrDefaultAsync(c => c.Id == id && !c.IsDeleted)
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
+        var client = await ctx.Clients.FirstOrDefaultAsync(c => c.Id == id && !c.IsDeleted, ct)
             ?? throw new EntityNotFoundException($"Client {id} not found.");
 
         client.IsArchived = false;
         client.DateUpdated = DateTime.Now;
-        await ctx.SaveChangesAsync();
+        await ctx.SaveChangesAsync(ct);
     }
 
-    public async Task DeleteClient(int id)
+    public async Task DeleteClient(int id, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
-        var client = await ctx.Clients.FirstOrDefaultAsync(c => c.Id == id && !c.IsDeleted)
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
+        var client = await ctx.Clients.FirstOrDefaultAsync(c => c.Id == id && !c.IsDeleted, ct)
             ?? throw new EntityNotFoundException($"Client {id} not found.");
 
-        var hasProjects = await ctx.Projects.AnyAsync(p => p.ClientId == id && !p.IsDeleted);
+        var hasProjects = await ctx.Projects.AnyAsync(p => p.ClientId == id && !p.IsDeleted, ct);
         if (hasProjects)
             throw new InvalidOperationException("Cannot delete a client that has active projects.");
 
         client.IsDeleted = true;
         client.DateDeleted = DateTime.Now;
-        await ctx.SaveChangesAsync();
+        await ctx.SaveChangesAsync(ct);
     }
 }

--- a/TimeTracker.Web/Features/Projects/ProjectEndpoints.cs
+++ b/TimeTracker.Web/Features/Projects/ProjectEndpoints.cs
@@ -11,30 +11,30 @@ public static class ProjectEndpoints
         var adminGroup = app.MapGroup("/api/projects").RequireAuthorization(
             new AuthorizationPolicyBuilder().RequireAuthenticatedUser().RequireRole("Admin").Build());
 
-        group.MapGet("/", async (IProjectService svc) =>
-            Results.Ok(await svc.GetAllProjects()));
+        group.MapGet("/", async (IProjectService svc, CancellationToken ct) =>
+            Results.Ok(await svc.GetAllProjects(ct)));
 
-        group.MapGet("/{id:int}", async (int id, IProjectService svc) =>
+        group.MapGet("/{id:int}", async (int id, IProjectService svc, CancellationToken ct) =>
         {
-            var result = await svc.GetProjectById(id);
+            var result = await svc.GetProjectById(id, ct);
             return result is null ? Results.NotFound() : Results.Ok(result);
         });
 
-        adminGroup.MapPost("/", async (ProjectCreateRequest request, IProjectService svc) =>
+        adminGroup.MapPost("/", async (ProjectCreateRequest request, IProjectService svc, CancellationToken ct) =>
         {
-            await svc.CreateProject(request);
+            await svc.CreateProject(request, ct);
             return Results.Created();
         }).RequireRateLimiting("write");
 
-        adminGroup.MapPut("/{id:int}", async (int id, ProjectUpdateRequest request, IProjectService svc) =>
+        adminGroup.MapPut("/{id:int}", async (int id, ProjectUpdateRequest request, IProjectService svc, CancellationToken ct) =>
         {
-            try { await svc.UpdateProject(id, request); return Results.NoContent(); }
+            try { await svc.UpdateProject(id, request, ct); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }
         }).RequireRateLimiting("write");
 
-        adminGroup.MapDelete("/{id:int}", async (int id, IProjectService svc) =>
+        adminGroup.MapDelete("/{id:int}", async (int id, IProjectService svc, CancellationToken ct) =>
         {
-            try { await svc.DeleteProject(id); return Results.NoContent(); }
+            try { await svc.DeleteProject(id, ct); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }
         }).RequireRateLimiting("write");
     }

--- a/TimeTracker.Web/Features/Projects/ProjectService.cs
+++ b/TimeTracker.Web/Features/Projects/ProjectService.cs
@@ -25,26 +25,26 @@ public class ProjectService : IProjectService
         ctx.Projects
             .Where(p => !p.IsDeleted && p.ProjectUsers.Any(pu => pu.UserId == userId));
 
-    public async Task<List<ProjectResponse>> GetAllProjects()
+    public async Task<List<ProjectResponse>> GetAllProjects(CancellationToken ct = default)
     {
         var userId = await GetUserIdAsync();
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
-        var projects = await UserProjects(ctx, userId).ToListAsync();
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
+        var projects = await UserProjects(ctx, userId).ToListAsync(ct);
         return projects.Adapt<List<ProjectResponse>>();
     }
 
-    public async Task<ProjectResponse?> GetProjectById(int id)
+    public async Task<ProjectResponse?> GetProjectById(int id, CancellationToken ct = default)
     {
         var userId = await GetUserIdAsync();
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
-        var project = await UserProjects(ctx, userId).FirstOrDefaultAsync(p => p.Id == id);
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
+        var project = await UserProjects(ctx, userId).FirstOrDefaultAsync(p => p.Id == id, ct);
         return project?.Adapt<ProjectResponse>();
     }
 
-    public async Task CreateProject(ProjectCreateRequest request)
+    public async Task CreateProject(ProjectCreateRequest request, CancellationToken ct = default)
     {
         var userId = await GetUserIdAsync();
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
         var project = new Project
         {
             Name = request.Name,
@@ -57,14 +57,14 @@ public class ProjectService : IProjectService
             ProjectUsers = new List<ProjectUser> { new() { UserId = userId } }
         };
         ctx.Projects.Add(project);
-        await ctx.SaveChangesAsync();
+        await ctx.SaveChangesAsync(ct);
     }
 
-    public async Task UpdateProject(int id, ProjectUpdateRequest request)
+    public async Task UpdateProject(int id, ProjectUpdateRequest request, CancellationToken ct = default)
     {
         var userId = await GetUserIdAsync();
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
-        var project = await UserProjects(ctx, userId).FirstOrDefaultAsync(p => p.Id == id)
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
+        var project = await UserProjects(ctx, userId).FirstOrDefaultAsync(p => p.Id == id, ct)
             ?? throw new EntityNotFoundException($"Project {id} not found.");
 
         project.Name = request.Name;
@@ -75,18 +75,18 @@ public class ProjectService : IProjectService
         project.EndDate = request.EndDate;
         project.DateUpdated = DateTime.Now;
 
-        await ctx.SaveChangesAsync();
+        await ctx.SaveChangesAsync(ct);
     }
 
-    public async Task DeleteProject(int id)
+    public async Task DeleteProject(int id, CancellationToken ct = default)
     {
         var userId = await GetUserIdAsync();
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
-        var project = await UserProjects(ctx, userId).FirstOrDefaultAsync(p => p.Id == id)
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
+        var project = await UserProjects(ctx, userId).FirstOrDefaultAsync(p => p.Id == id, ct)
             ?? throw new EntityNotFoundException($"Project {id} not found.");
 
         project.IsDeleted = true;
         project.DateDeleted = DateTime.Now;
-        await ctx.SaveChangesAsync();
+        await ctx.SaveChangesAsync(ct);
     }
 }

--- a/TimeTracker.Web/Features/TimeEntries/TimeEntryEndpoints.cs
+++ b/TimeTracker.Web/Features/TimeEntries/TimeEntryEndpoints.cs
@@ -8,57 +8,57 @@ public static class TimeEntryEndpoints
     {
         var group = app.MapGroup("/api/timeentries").RequireAuthorization();
 
-        group.MapGet("/active", async (ITimeEntryService svc) =>
+        group.MapGet("/active", async (ITimeEntryService svc, CancellationToken ct) =>
         {
-            var entry = await svc.GetActiveTimeEntry();
+            var entry = await svc.GetActiveTimeEntry(ct);
             return entry is null ? Results.NoContent() : Results.Ok(entry);
         });
 
-        group.MapGet("/today", async (ITimeEntryService svc) =>
-            Results.Ok(await svc.GetTodaysTimeEntries()));
+        group.MapGet("/today", async (ITimeEntryService svc, CancellationToken ct) =>
+            Results.Ok(await svc.GetTodaysTimeEntries(ct)));
 
-        group.MapGet("/year/{year:int}/all", async (int year, ITimeEntryService svc) =>
-            Results.Ok(await svc.GetAllTimeEntriesByYear(year))).RequireRateLimiting("all-entries");
+        group.MapGet("/year/{year:int}/all", async (int year, ITimeEntryService svc, CancellationToken ct) =>
+            Results.Ok(await svc.GetAllTimeEntriesByYear(year, ct))).RequireRateLimiting("all-entries");
 
-        group.MapGet("/{skip:int}/{limit:int}", async (int skip, int limit, ITimeEntryQueryService svc) =>
-            Results.Ok(await svc.GetTimeEntries(skip, limit)));
+        group.MapGet("/{skip:int}/{limit:int}", async (int skip, int limit, ITimeEntryQueryService svc, CancellationToken ct) =>
+            Results.Ok(await svc.GetTimeEntries(skip, limit, ct)));
 
-        group.MapGet("/{id:int}", async (int id, ITimeEntryService svc) =>
+        group.MapGet("/{id:int}", async (int id, ITimeEntryService svc, CancellationToken ct) =>
         {
-            var result = await svc.GetTimeEntryById(id);
+            var result = await svc.GetTimeEntryById(id, ct);
             return result is null ? Results.NotFound() : Results.Ok(result);
         });
 
-        group.MapGet("/project/{projectId:int}/all", async (int projectId, ITimeEntryService svc) =>
-            Results.Ok(await svc.GetAllTimeEntriesByProject(projectId))).RequireRateLimiting("all-entries");
+        group.MapGet("/project/{projectId:int}/all", async (int projectId, ITimeEntryService svc, CancellationToken ct) =>
+            Results.Ok(await svc.GetAllTimeEntriesByProject(projectId, ct))).RequireRateLimiting("all-entries");
 
-        group.MapGet("/project/{projectId:int}/{skip:int}/{limit:int}", async (int projectId, int skip, int limit, ITimeEntryQueryService svc) =>
-            Results.Ok(await svc.GetTimeEntriesByProjectId(projectId, skip, limit)));
+        group.MapGet("/project/{projectId:int}/{skip:int}/{limit:int}", async (int projectId, int skip, int limit, ITimeEntryQueryService svc, CancellationToken ct) =>
+            Results.Ok(await svc.GetTimeEntriesByProjectId(projectId, skip, limit, ct)));
 
-        group.MapGet("/year/{year:int}/{skip:int}/{limit:int}", async (int year, int skip, int limit, ITimeEntryQueryService svc) =>
-            Results.Ok(await svc.GetTimeEntriesByYear(year, skip, limit)));
+        group.MapGet("/year/{year:int}/{skip:int}/{limit:int}", async (int year, int skip, int limit, ITimeEntryQueryService svc, CancellationToken ct) =>
+            Results.Ok(await svc.GetTimeEntriesByYear(year, skip, limit, ct)));
 
-        group.MapGet("/month/{month:int}/year/{year:int}/{skip:int}/{limit:int}", async (int month, int year, int skip, int limit, ITimeEntryQueryService svc) =>
-            Results.Ok(await svc.GetTimeEntriesByMonth(month, year, skip, limit)));
+        group.MapGet("/month/{month:int}/year/{year:int}/{skip:int}/{limit:int}", async (int month, int year, int skip, int limit, ITimeEntryQueryService svc, CancellationToken ct) =>
+            Results.Ok(await svc.GetTimeEntriesByMonth(month, year, skip, limit, ct)));
 
-        group.MapGet("/day/{day:int}/month/{month:int}/year/{year:int}/{skip:int}/{limit:int}", async (int day, int month, int year, int skip, int limit, ITimeEntryQueryService svc) =>
-            Results.Ok(await svc.GetTimeEntriesByDay(day, month, year, skip, limit)));
+        group.MapGet("/day/{day:int}/month/{month:int}/year/{year:int}/{skip:int}/{limit:int}", async (int day, int month, int year, int skip, int limit, ITimeEntryQueryService svc, CancellationToken ct) =>
+            Results.Ok(await svc.GetTimeEntriesByDay(day, month, year, skip, limit, ct)));
 
-        group.MapPost("/", async (TimeEntryCreateRequest request, ITimeEntryService svc) =>
+        group.MapPost("/", async (TimeEntryCreateRequest request, ITimeEntryService svc, CancellationToken ct) =>
         {
-            await svc.CreateTimeEntry(request);
+            await svc.CreateTimeEntry(request, ct);
             return Results.Created();
         }).RequireRateLimiting("write");
 
-        group.MapPut("/{id:int}", async (int id, TimeEntryUpdateRequest request, ITimeEntryService svc) =>
+        group.MapPut("/{id:int}", async (int id, TimeEntryUpdateRequest request, ITimeEntryService svc, CancellationToken ct) =>
         {
-            try { await svc.UpdateTimeEntry(id, request); return Results.NoContent(); }
+            try { await svc.UpdateTimeEntry(id, request, ct); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }
         }).RequireRateLimiting("write");
 
-        group.MapDelete("/{id:int}", async (int id, ITimeEntryService svc) =>
+        group.MapDelete("/{id:int}", async (int id, ITimeEntryService svc, CancellationToken ct) =>
         {
-            try { await svc.DeleteTimeEntry(id); return Results.NoContent(); }
+            try { await svc.DeleteTimeEntry(id, ct); return Results.NoContent(); }
             catch (EntityNotFoundException) { return Results.NotFound(); }
         }).RequireRateLimiting("write");
     }

--- a/TimeTracker.Web/Features/TimeEntries/TimeEntryService.cs
+++ b/TimeTracker.Web/Features/TimeEntries/TimeEntryService.cs
@@ -24,25 +24,22 @@ public class TimeEntryService : ITimeEntryService, ITimeEntryQueryService
     private static IQueryable<TimeEntry> UserEntries(TimeTrackerDataContext ctx, string userId) =>
         ctx.TimeEntries
             .Include(te => te.Project)
-
             .Where(te => te.UserId == userId && !te.Project.IsDeleted);
 
-
-    public async Task<TimeEntryResponse?> GetTimeEntryById(int id)
+    public async Task<TimeEntryResponse?> GetTimeEntryById(int id, CancellationToken ct = default)
     {
         var userId = await GetUserIdAsync();
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
         var entry = await ctx.TimeEntries
             .Include(te => te.Project)
-
-            .FirstOrDefaultAsync(te => te.Id == id && te.UserId == userId);
+            .FirstOrDefaultAsync(te => te.Id == id && te.UserId == userId, ct);
         return entry?.Adapt<TimeEntryResponse>();
     }
 
-    public async Task CreateTimeEntry(TimeEntryCreateRequest request)
+    public async Task CreateTimeEntry(TimeEntryCreateRequest request, CancellationToken ct = default)
     {
         var userId = await GetUserIdAsync();
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
         var entry = new TimeEntry
         {
             ProjectId = request.ProjectId,
@@ -53,15 +50,15 @@ public class TimeEntryService : ITimeEntryService, ITimeEntryQueryService
             DateCreated = DateTime.Now
         };
         ctx.TimeEntries.Add(entry);
-        await ctx.SaveChangesAsync();
+        await ctx.SaveChangesAsync(ct);
     }
 
-    public async Task UpdateTimeEntry(int id, TimeEntryUpdateRequest request)
+    public async Task UpdateTimeEntry(int id, TimeEntryUpdateRequest request, CancellationToken ct = default)
     {
         var userId = await GetUserIdAsync();
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
         var entry = await ctx.TimeEntries
-            .FirstOrDefaultAsync(te => te.Id == id && te.UserId == userId)
+            .FirstOrDefaultAsync(te => te.Id == id && te.UserId == userId, ct)
             ?? throw new EntityNotFoundException($"Time entry {id} not found.");
 
         entry.ProjectId = request.ProjectId;
@@ -71,110 +68,109 @@ public class TimeEntryService : ITimeEntryService, ITimeEntryQueryService
         entry.InvoiceReference = request.InvoiceReference;
         entry.InvoicedAt = request.InvoicedAt;
         entry.DateUpdated = DateTime.Now;
-        await ctx.SaveChangesAsync();
+        await ctx.SaveChangesAsync(ct);
     }
 
-    public async Task DeleteTimeEntry(int id)
+    public async Task DeleteTimeEntry(int id, CancellationToken ct = default)
     {
         var userId = await GetUserIdAsync();
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
         var entry = await ctx.TimeEntries
-            .FirstOrDefaultAsync(te => te.Id == id && te.UserId == userId)
+            .FirstOrDefaultAsync(te => te.Id == id && te.UserId == userId, ct)
             ?? throw new EntityNotFoundException($"Time entry {id} not found.");
 
         ctx.TimeEntries.Remove(entry);
-        await ctx.SaveChangesAsync();
+        await ctx.SaveChangesAsync(ct);
     }
 
-    public async Task<TimeEntryResponseWrapper> GetTimeEntries(int skip, int limit)
+    public async Task<TimeEntryResponseWrapper> GetTimeEntries(int skip, int limit, CancellationToken ct = default)
     {
         var userId = await GetUserIdAsync();
-        return await ToWrapper((ctx, uid) => UserEntries(ctx, uid), userId, skip, limit);
+        return await ToWrapper((ctx, uid) => UserEntries(ctx, uid), userId, skip, limit, ct);
     }
 
-    public async Task<TimeEntryResponseWrapper> GetTimeEntriesByProjectId(int projectId, int skip, int limit)
+    public async Task<TimeEntryResponseWrapper> GetTimeEntriesByProjectId(int projectId, int skip, int limit, CancellationToken ct = default)
     {
         var userId = await GetUserIdAsync();
-        return await ToWrapper((ctx, uid) => UserEntries(ctx, uid).Where(te => te.ProjectId == projectId), userId, skip, limit);
+        return await ToWrapper((ctx, uid) => UserEntries(ctx, uid).Where(te => te.ProjectId == projectId), userId, skip, limit, ct);
     }
 
-    public async Task<TimeEntryResponseWrapper> GetTimeEntriesByYear(int year, int skip, int limit)
+    public async Task<TimeEntryResponseWrapper> GetTimeEntriesByYear(int year, int skip, int limit, CancellationToken ct = default)
     {
         var userId = await GetUserIdAsync();
-        return await ToWrapper((ctx, uid) => UserEntries(ctx, uid).Where(te => te.Start.Year == year), userId, skip, limit);
+        return await ToWrapper((ctx, uid) => UserEntries(ctx, uid).Where(te => te.Start.Year == year), userId, skip, limit, ct);
     }
 
-    public async Task<TimeEntryResponseWrapper> GetTimeEntriesByMonth(int month, int year, int skip, int limit)
+    public async Task<TimeEntryResponseWrapper> GetTimeEntriesByMonth(int month, int year, int skip, int limit, CancellationToken ct = default)
     {
         var userId = await GetUserIdAsync();
-        return await ToWrapper((ctx, uid) => UserEntries(ctx, uid).Where(te => te.Start.Year == year && te.Start.Month == month), userId, skip, limit);
+        return await ToWrapper((ctx, uid) => UserEntries(ctx, uid).Where(te => te.Start.Year == year && te.Start.Month == month), userId, skip, limit, ct);
     }
 
-    public async Task<TimeEntryResponseWrapper> GetTimeEntriesByDay(int day, int month, int year, int skip, int limit)
+    public async Task<TimeEntryResponseWrapper> GetTimeEntriesByDay(int day, int month, int year, int skip, int limit, CancellationToken ct = default)
     {
         var userId = await GetUserIdAsync();
         return await ToWrapper((ctx, uid) => UserEntries(ctx, uid)
-            .Where(te => te.Start.Year == year && te.Start.Month == month && te.Start.Day == day), userId, skip, limit);
+            .Where(te => te.Start.Year == year && te.Start.Month == month && te.Start.Day == day), userId, skip, limit, ct);
     }
 
-    public async Task<List<TimeEntryResponse>> GetAllTimeEntriesByYear(int year)
+    public async Task<List<TimeEntryResponse>> GetAllTimeEntriesByYear(int year, CancellationToken ct = default)
     {
         var userId = await GetUserIdAsync();
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
         var entries = await UserEntries(ctx, userId)
             .Where(te => te.Start.Year == year)
-            .ToListAsync();
+            .ToListAsync(ct);
         return entries.Adapt<List<TimeEntryResponse>>();
     }
 
-    public async Task<TimeEntryResponse?> GetActiveTimeEntry()
+    public async Task<TimeEntryResponse?> GetActiveTimeEntry(CancellationToken ct = default)
     {
         var userId = await GetUserIdAsync();
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
         var entry = await ctx.TimeEntries
             .Include(te => te.Project)
-
-            .FirstOrDefaultAsync(te => te.UserId == userId && te.End == null && !te.Project.IsDeleted);
+            .FirstOrDefaultAsync(te => te.UserId == userId && te.End == null && !te.Project.IsDeleted, ct);
         return entry?.Adapt<TimeEntryResponse>();
     }
 
-    public async Task<List<TimeEntryResponse>> GetTodaysTimeEntries()
+    public async Task<List<TimeEntryResponse>> GetTodaysTimeEntries(CancellationToken ct = default)
     {
         var userId = await GetUserIdAsync();
         var today = DateTime.Today;
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
         var entries = await UserEntries(ctx, userId)
             .Where(te => te.Start.Date == today)
             .OrderByDescending(te => te.Start)
-            .ToListAsync();
+            .ToListAsync(ct);
         return entries.Adapt<List<TimeEntryResponse>>();
     }
 
-    public async Task<List<TimeEntryResponse>> GetAllTimeEntriesByProject(int projectId)
+    public async Task<List<TimeEntryResponse>> GetAllTimeEntriesByProject(int projectId, CancellationToken ct = default)
     {
         var userId = await GetUserIdAsync();
-        await using var ctx = await _contextFactory.CreateDbContextAsync();
+        await using var ctx = await _contextFactory.CreateDbContextAsync(ct);
         var entries = await UserEntries(ctx, userId)
             .Where(te => te.ProjectId == projectId)
             .OrderByDescending(te => te.Start)
-            .ToListAsync();
+            .ToListAsync(ct);
         return entries.Adapt<List<TimeEntryResponse>>();
     }
 
     private async Task<TimeEntryResponseWrapper> ToWrapper(
         Func<TimeTrackerDataContext, string, IQueryable<TimeEntry>> queryBuilder,
-        string userId, int skip, int limit)
+        string userId, int skip, int limit, CancellationToken ct)
     {
-        await using var dataCtx = await _contextFactory.CreateDbContextAsync();
-        await using var countCtx = await _contextFactory.CreateDbContextAsync();
-        await using var durationCtx = await _contextFactory.CreateDbContextAsync();
+        await using var dataCtx = await _contextFactory.CreateDbContextAsync(ct);
+        await using var countCtx = await _contextFactory.CreateDbContextAsync(ct);
+        await using var durationCtx = await _contextFactory.CreateDbContextAsync(ct);
 
-        var dataTask = queryBuilder(dataCtx, userId).Skip(skip).Take(Math.Min(limit, 200)).ToListAsync();
-        var countTask = queryBuilder(countCtx, userId).CountAsync();
+        var dataTask = queryBuilder(dataCtx, userId).Skip(skip).Take(Math.Min(limit, 200)).ToListAsync(ct);
+        var countTask = queryBuilder(countCtx, userId).CountAsync(ct);
         var durationTask = queryBuilder(durationCtx, userId)
             .Where(te => te.End.HasValue)
             .Select(te => new { te.Start, End = te.End!.Value })
-            .ToListAsync();
+            .ToListAsync(ct);
 
         await Task.WhenAll(dataTask, countTask, durationTask);
 


### PR DESCRIPTION
## Summary
- Adds `CancellationToken ct = default` to all methods in `ITimeEntryService`, `ITimeEntryQueryService`, `IProjectService`, and `IClientService`
- Minimal API endpoints bind `HttpContext.RequestAborted` automatically via the `CancellationToken` parameter
- All EF Core async calls (`ToListAsync`, `FirstOrDefaultAsync`, `SaveChangesAsync`, `CreateDbContextAsync`, etc.) now receive `ct`
- WASM `Http*` client implementations pass `ct` through to `HttpClient` calls
- `Mock*` implementations accept `ct = default` (in-memory, no async I/O)
- Test stub inner classes (`StubProjectService`, `StubClientService`) updated to match interfaces

## Test plan
- [x] `dotnet test` — 106/106 pass
- [x] Playwright pre-push hook — 35/35 pass (2 write tests skipped)

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)