### PR TITLE
feat: add session revocation via SecurityStamp (#103)

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -2,25 +2,17 @@
 
 ## Current state
 - Branch: `main`, clean
-- PRs #114 (#111), #117 (#116), #118 (#100) all merged this session
-- New issues created: #115 (cancellation tokens), #116 (pagination cap)
+- PRs #114 (#111), #117 (#116), #118 (#100), #119 (#115) all merged this session
 
 ## Completed this session
 - ✅ #111 Program.cs refactor (PR #114)
 - ✅ #116 Server-side pagination cap + timer dispose fix (PR #117)
 - ✅ #100 Global rate limiting covering all endpoints (PR #118)
 - ✅ D018 added to decisions.md, architecture.md updated
+- ✅ #115 Cancellation tokens threaded through all service methods and EF Core calls (PR #119)
+- ✅ #103 Session revocation via SecurityStamp (PR in progress)
 
 ## Plan — remaining medium priority (work in order)
-
-### Next up — Step C (before moving on)
-- **#115** 🟢 Cancellation tokens — thread `CancellationToken` through all service methods and EF Core calls
-  - All service interfaces + implementations (TimeEntries, Projects, Clients, Auth)
-  - All EF Core async calls (`ToListAsync`, `FirstOrDefaultAsync`, `SaveChangesAsync`, etc.)
-  - Largest refactor of the defence-in-depth batch; do before Step 3
-
-### Step 3 — Session revocation
-- **#103** 🟡 Session revocation via SecurityStamp
 
 ### Step 4 — Structured logging & monitoring
 - **#97** 🟡 Structured logging (Serilog), APM (Application Insights), uptime monitoring (UptimeRobot), `/health` endpoint
@@ -33,7 +25,6 @@
 - **#95** 🟢 Database-backed user management
 - **#96** 🟢 Staging environment (requires paid tier upgrade)
 - **#102** 🟢 Email/password fallback + TOTP MFA
-- **#115** 🟢 Cancellation tokens (defence-in-depth, Step C)
 
 ## Active tech debt (genuine constraints, no action until paid tier)
 | # | Item | ADR |
@@ -53,4 +44,4 @@ cat SESSION.md
 ```
 
 ---
-*Updated 2026-06-14. Next: #115 cancellation tokens (Step C), then Step 3 session revocation.*
+*Updated 2026-06-14. Next: Step 4 (#97 structured logging), Step 5 (#101 RLS, #104 backup).*

--- a/TimeTracker.Tests/Features/Auth/AuthEndpointAuthTests.cs
+++ b/TimeTracker.Tests/Features/Auth/AuthEndpointAuthTests.cs
@@ -1,0 +1,65 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using TimeTracker.Shared.Entities;
+using TimeTracker.Web.Data;
+using TimeTracker.Web.Features.Auth;
+using Xunit;
+
+namespace TimeTracker.Tests.Features.Auth;
+
+public class AuthEndpointAuthTests
+{
+    private static IReadOnlyList<Endpoint> BuildEndpoints()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddRouting();
+        builder.Services.AddAuthorization();
+        builder.Services.AddDbContext<IdentityDataContext>(o =>
+            o.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+        builder.Services.AddIdentity<User, IdentityRole>()
+            .AddEntityFrameworkStores<IdentityDataContext>();
+        builder.Services.AddAuthentication();
+        builder.Services.AddScoped<IExternalLoginService>(_ => new StubExternalLoginService());
+        var app = builder.Build();
+        app.MapAuthEndpoints();
+        return ((IEndpointRouteBuilder)app).DataSources.SelectMany(s => s.Endpoints).ToList();
+    }
+
+    private static bool HasAdminRole(Endpoint endpoint) =>
+        endpoint.Metadata
+            .OfType<AuthorizationPolicy>()
+            .Any(p => p.Requirements
+                .OfType<RolesAuthorizationRequirement>()
+                .Any(r => r.AllowedRoles.Contains("Admin")))
+        || endpoint.Metadata
+            .OfType<IAuthorizeData>()
+            .Any(a => a.Roles?.Contains("Admin") == true);
+
+    private static Endpoint? Find(IReadOnlyList<Endpoint> endpoints, string method, string pattern) =>
+        endpoints.OfType<RouteEndpoint>()
+            .FirstOrDefault(e =>
+                e.RoutePattern.RawText == pattern &&
+                e.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods.Contains(method) == true);
+
+    [Fact]
+    public void RevokeSessionsEndpoint_RequiresAdminRole()
+    {
+        var endpoints = BuildEndpoints();
+        var endpoint = Find(endpoints, "POST", "/api/auth/revoke-sessions");
+        Assert.NotNull(endpoint);
+        Assert.True(HasAdminRole(endpoint),
+            "POST /api/auth/revoke-sessions must require the Admin role but does not.");
+    }
+
+    private sealed class StubExternalLoginService : IExternalLoginService
+    {
+        public Task<ExternalLoginResult> FindOrCreateUserAsync(string email, string loginProvider, string providerKey) =>
+            Task.FromResult(new ExternalLoginResult(ExternalLoginStatus.Success));
+    }
+}

--- a/TimeTracker.Web/Features/Auth/AuthEndpoints.cs
+++ b/TimeTracker.Web/Features/Auth/AuthEndpoints.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
+using System.Security.Claims;
 using TimeTracker.Contracts.Auth;
 using TimeTracker.Shared.Entities;
 
@@ -19,8 +21,10 @@ public static class AuthEndpoints
         app.MapGet("/auth/callback", async (
             SignInManager<User> signInManager,
             IExternalLoginService externalLoginService,
+            ILoggerFactory loggerFactory,
             string? returnUrl) =>
         {
+            var logger = loggerFactory.CreateLogger("Auth");
             var info = await signInManager.GetExternalLoginInfoAsync();
             if (info is null)
                 return Results.Redirect("/login?error=external-login-failed");
@@ -32,21 +36,54 @@ public static class AuthEndpoints
             var result = await externalLoginService.FindOrCreateUserAsync(email, info.LoginProvider, info.ProviderKey);
 
             if (result.Status == ExternalLoginStatus.EmailNotAllowed)
+            {
+                logger.LogWarning("Auth: login rejected — email {Email} not in allowed list", email);
                 return Results.Redirect("/access-denied");
+            }
 
             if (result.Status != ExternalLoginStatus.Success)
+            {
+                logger.LogWarning("Auth: login failed for {Email} with status {Status}", email, result.Status);
                 return Results.Redirect($"/login?error={result.Status.ToString().ToLowerInvariant().Replace("_", "-")}");
+            }
 
             await signInManager.SignInAsync(result.User!, isPersistent: true);
+            logger.LogInformation("Auth: user {Email} signed in via {Provider}", email, info.LoginProvider);
             var safeReturnUrl = Uri.TryCreate(returnUrl, UriKind.Relative, out _) ? returnUrl! : "/timeentries";
             return Results.LocalRedirect(safeReturnUrl);
         }).RequireRateLimiting("auth");
 
-        app.MapPost("/auth/logout", async (SignInManager<User> signInManager) =>
+        app.MapPost("/auth/logout", async (
+            SignInManager<User> signInManager,
+            UserManager<User> userManager,
+            ClaimsPrincipal principal,
+            ILoggerFactory loggerFactory) =>
         {
+            var logger = loggerFactory.CreateLogger("Auth");
+            var user = await userManager.GetUserAsync(principal);
+            if (user is not null)
+            {
+                await userManager.UpdateSecurityStampAsync(user);
+                logger.LogInformation("Auth: security stamp rotated on logout for {Email}", user.Email);
+            }
             await signInManager.SignOutAsync();
             return Results.Redirect("/login");
         });
+
+        app.MapPost("/api/auth/revoke-sessions", async (
+            UserManager<User> userManager,
+            ClaimsPrincipal principal,
+            ILoggerFactory loggerFactory) =>
+        {
+            var logger = loggerFactory.CreateLogger("Auth");
+            var user = await userManager.GetUserAsync(principal);
+            if (user is null) return Results.Unauthorized();
+            await userManager.UpdateSecurityStampAsync(user);
+            logger.LogInformation("Auth: all sessions revoked for {Email}", user.Email);
+            return Results.Ok();
+        }).RequireAuthorization(
+            new AuthorizationPolicyBuilder().RequireAuthenticatedUser().RequireRole("Admin").Build()
+        ).RequireRateLimiting("write");
 
         app.MapGet("/api/auth/providers", async (IAuthenticationSchemeProvider schemeProvider) =>
         {

--- a/TimeTracker.Web/Infrastructure/AuthServiceExtensions.cs
+++ b/TimeTracker.Web/Infrastructure/AuthServiceExtensions.cs
@@ -19,6 +19,12 @@ public static class AuthServiceExtensions
             .AddDefaultTokenProviders()
             .AddClaimsPrincipalFactory<AppUserClaimsPrincipalFactory>();
 
+        services.Configure<SecurityStampValidatorOptions>(options =>
+        {
+            options.ValidationInterval = TimeSpan.FromMinutes(
+                configuration.GetValue<int>("Authentication:SecurityStampValidationIntervalMinutes", 30));
+        });
+
         services.ConfigureApplicationCookie(options =>
         {
             options.Cookie.HttpOnly = true;


### PR DESCRIPTION
## Summary
- Enables `SecurityStampValidator` with configurable 30-min validation interval (`Authentication:SecurityStampValidationIntervalMinutes`, default 30) — rotates the stamp DB check window rather than leaving it implicit
- Rotates the security stamp on explicit logout, immediately invalidating all other active sessions on their next validated request
- Adds `POST /api/auth/revoke-sessions` (Admin-only) for forced logout from all devices without requiring the current session to end
- Adds structured `ILogger` log entries for: login success/failure, logout with stamp rotation, and session revocation
- Adds `AuthEndpointAuthTests` verifying the revoke endpoint requires Admin role

## Test plan
- [x] `dotnet test` — 107/107 pass (1 new test: `RevokeSessionsEndpoint_RequiresAdminRole`)
- [x] Playwright pre-push hook — 35/35 pass (2 write tests skipped)

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)