### PR TITLE
fix: remove email from auth log messages (CWE-359)

### DIFF
--- a/TimeTracker.Web/Features/Auth/AuthEndpoints.cs
+++ b/TimeTracker.Web/Features/Auth/AuthEndpoints.cs
@@ -37,18 +37,18 @@ public static class AuthEndpoints
 
             if (result.Status == ExternalLoginStatus.EmailNotAllowed)
             {
-                logger.LogWarning("Auth: login rejected — email {Email} not in allowed list", email);
+                logger.LogWarning("Auth: login rejected — email not in allowed list");
                 return Results.Redirect("/access-denied");
             }
 
             if (result.Status != ExternalLoginStatus.Success)
             {
-                logger.LogWarning("Auth: login failed for {Email} with status {Status}", email, result.Status);
+                logger.LogWarning("Auth: login failed with status {Status}", result.Status);
                 return Results.Redirect($"/login?error={result.Status.ToString().ToLowerInvariant().Replace("_", "-")}");
             }
 
             await signInManager.SignInAsync(result.User!, isPersistent: true);
-            logger.LogInformation("Auth: user {Email} signed in via {Provider}", email, info.LoginProvider);
+            logger.LogInformation("Auth: user signed in via {Provider}", info.LoginProvider);
             var safeReturnUrl = Uri.TryCreate(returnUrl, UriKind.Relative, out _) ? returnUrl! : "/timeentries";
             return Results.LocalRedirect(safeReturnUrl);
         }).RequireRateLimiting("auth");
@@ -64,7 +64,7 @@ public static class AuthEndpoints
             if (user is not null)
             {
                 await userManager.UpdateSecurityStampAsync(user);
-                logger.LogInformation("Auth: security stamp rotated on logout for {Email}", user.Email);
+                logger.LogInformation("Auth: security stamp rotated on logout");
             }
             await signInManager.SignOutAsync();
             return Results.Redirect("/login");
@@ -79,7 +79,7 @@ public static class AuthEndpoints
             var user = await userManager.GetUserAsync(principal);
             if (user is null) return Results.Unauthorized();
             await userManager.UpdateSecurityStampAsync(user);
-            logger.LogInformation("Auth: all sessions revoked for {Email}", user.Email);
+            logger.LogInformation("Auth: all sessions revoked");
             return Results.Ok();
         }).RequireAuthorization(
             new AuthorizationPolicyBuilder().RequireAuthenticatedUser().RequireRole("Admin").Build()


### PR DESCRIPTION
## Summary

- Removes email addresses from all five auth log statements in `AuthEndpoints.cs`
- Email is PII — logging it to structured logs writes private data to an external location (CWE-359 / GDPR concern)
- Status, provider, and event type are retained — sufficient for debugging without exposing PII

## Resolves

Closes CodeQL alerts #4, #5, #6, #7 (`cs/exposure-of-sensitive-information`)

## Test plan

- [ ] 107 unit tests passing
- [ ] 36 Playwright tests passing (2 write tests skipped as expected)
- [ ] CodeQL re-scan should clear all four alerts on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)