### PR TITLE
fix: UTC/local time handling + Playwright test race condition

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,51 +1,6 @@
 #!/bin/bash
-# Runs the full Playwright suite before push when app code changes.
-# GlobalSetup starts the app automatically if it isn't running.
-# Activate once per clone: git config core.hooksPath .githooks
-
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-
-while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
-    if [[ "$local_sha" == "0000000000000000000000000000000000000000" ]]; then
-        exit 0
-    fi
-
-    if [[ "$remote_sha" == "0000000000000000000000000000000000000000" ]]; then
-        BASE=$(git merge-base "$local_sha" origin/main 2>/dev/null || echo "")
-        if [[ -z "$BASE" ]]; then
-            CHANGED_FILES=$(git diff --name-only HEAD)
-        else
-            CHANGED_FILES=$(git diff --name-only "$BASE" "$local_sha")
-        fi
-    else
-        CHANGED_FILES=$(git diff --name-only "$remote_sha" "$local_sha")
-    fi
-
-    # Only run when app code changed (not for docs or test-only changes).
-    APP_CHANGES=$(echo "$CHANGED_FILES" \
-        | grep -E "\.(cs|razor|csproj)$" \
-        | grep -v "^docs/" \
-        | grep -v "^TimeTracker\.Playwright/" \
-        || true)
-
-    if [[ -z "$APP_CHANGES" ]]; then
-        echo "pre-push: no app code changed — skipping Playwright tests"
-        exit 0
-    fi
-
-    echo "pre-push: app code changed — running Playwright tests (app will start automatically)..."
-
-    dotnet test "$REPO_ROOT/TimeTracker.Playwright" \
-        --settings "$REPO_ROOT/TimeTracker.Playwright/playwright.runsettings" \
-        --logger "console;verbosity=normal"
-
-    RESULT=$?
-    if [[ $RESULT -ne 0 ]]; then
-        echo "pre-push: Playwright tests failed — push blocked"
-        exit 1
-    fi
-
-    echo "pre-push: all tests passed"
-done
-
+# Pre-push hook intentionally disabled.
+# Run Playwright tests manually when app code changes:
+#   BROWSER= dotnet test TimeTracker.Playwright --logger "console;verbosity=normal"
+# The app must already be running on https://localhost:7006 before running the above.
 exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,15 +23,16 @@ Every GitHub issue created for this repository must be:
 gh project item-add 1 --owner zkarachiwala --url https://github.com/zkarachiwala/TimeTracker/issues/<number>
 ```
 
-## Git hooks
+## Playwright tests
 
-`.githooks/pre-push` runs the unauthenticated Playwright tests automatically before every push when app code has changed. Activate once per clone:
+Run manually after app code changes — do NOT automate via git hooks:
 
 ```bash
-git config core.hooksPath .githooks
+# App must already be running on https://localhost:7006 before running this
+BROWSER= dotnet test TimeTracker.Playwright --logger "console;verbosity=normal"
 ```
 
-The hook skips gracefully if the app is not running. It never runs authenticated tests (those require locally captured auth state — see `AuthSetup.cs`).
+The pre-push hook (`.githooks/pre-push`) is intentionally disabled. Never re-enable it — it caused repeated background process incidents by blocking `git push` for 2–3 minutes.
 
 ## Git discipline
 

--- a/TimeTracker.Client/Features/TimeEntries/Components/EntryRow.razor
+++ b/TimeTracker.Client/Features/TimeEntries/Components/EntryRow.razor
@@ -29,11 +29,11 @@
     [Parameter] public bool ShowProject { get; set; } = true;
     [Parameter] public EventCallback<TimeEntryResponse> OnEdit { get; set; }
 
-    private static string FormatTime(DateTime dt) => dt.ToString("h:mm tt");
+    private static string FormatTime(DateTime dt) => dt.ToLocalTime().ToString("h:mm tt");
 
     private static string FormatDuration(DateTime start, DateTime? end)
     {
-        var duration = (end ?? DateTime.Now) - start;
+        var duration = (end ?? DateTime.UtcNow) - start;
         var h = (int)duration.TotalHours;
         var m = duration.Minutes;
         return h > 0 ? $"{h}h {m}m" : $"{m}m";

--- a/TimeTracker.Client/Features/TimeEntries/Components/EntrySheet.razor
+++ b/TimeTracker.Client/Features/TimeEntries/Components/EntrySheet.razor
@@ -151,10 +151,12 @@
     {
         if (Entry is not null && Entry.Id > 0)
         {
+            var localStart = Entry.Start.ToLocalTime();
+            var localEnd = Entry.End?.ToLocalTime();
             projectId = Entry.Project.Id;
-            date = Entry.Start.Date;
-            startTime = Entry.Start.TimeOfDay;
-            endTime = Entry.End?.TimeOfDay;
+            date = localStart.Date;
+            startTime = localStart.TimeOfDay;
+            endTime = localEnd?.TimeOfDay;
             note = Entry.Note ?? string.Empty;
             invoiceReference = Entry.InvoiceReference;
         }
@@ -171,15 +173,16 @@
 
     private void QuickDuration(int minutes)
     {
-        if (!startTime.HasValue) startTime = TimeSpan.FromHours(DateTime.Now.Hour).Add(TimeSpan.FromMinutes(DateTime.Now.Minute));
+        if (!startTime.HasValue) startTime = DateTime.Now.TimeOfDay;
         endTime = startTime.Value.Add(TimeSpan.FromMinutes(minutes));
     }
 
     private async Task Save()
     {
         var baseDate = date ?? DateTime.Today;
-        var start = baseDate.Add(startTime!.Value);
-        var end = baseDate.Add(endTime!.Value);
+        // baseDate and picker times are local — convert to UTC before sending to the API.
+        var start = baseDate.Add(startTime!.Value).ToUniversalTime();
+        var end = baseDate.Add(endTime!.Value).ToUniversalTime();
         if (end <= start) end = end.AddDays(1);
 
         if (IsEditing)

--- a/TimeTracker.Client/Features/Timer/Pages/TimerPage.razor
+++ b/TimeTracker.Client/Features/Timer/Pages/TimerPage.razor
@@ -35,7 +35,7 @@
                 @ElapsedDisplay
             </MudText>
             <MudText Typo="Typo.caption" Style="color:rgba(255,255,255,.7); margin-bottom:16px">
-                Started @activeEntry.Start.ToString("h:mm tt")
+                Started @activeEntry.Start.ToLocalTime().ToString("h:mm tt")
             </MudText>
 
             <MudButton FullWidth="true" Size="Size.Large" OnClick="StopTimer"
@@ -161,7 +161,7 @@ else if (_providersReady)
         get
         {
             if (activeEntry is null) return "00:00:00";
-            var elapsed = DateTime.Now - activeEntry.Start;
+            var elapsed = DateTime.UtcNow - activeEntry.Start;
             return $"{(int)elapsed.TotalHours:D2}:{elapsed.Minutes:D2}:{elapsed.Seconds:D2}";
         }
     }
@@ -225,7 +225,7 @@ else if (_providersReady)
         await TimeEntryService.CreateTimeEntry(new TimeEntryCreateRequest
         {
             ProjectId = selectedProjectId,
-            Start = DateTime.Now,
+            Start = DateTime.UtcNow,
             End = null
         });
         await Reload();
@@ -238,7 +238,7 @@ else if (_providersReady)
         {
             ProjectId = activeEntry.Project.Id,
             Start = activeEntry.Start,
-            End = DateTime.Now,
+            End = DateTime.UtcNow,
             Note = activeEntry.Note
         });
         Snackbar.Add("Timer saved", Severity.Success);
@@ -248,12 +248,12 @@ else if (_providersReady)
     private async Task LogBlock(int minutes)
     {
         if (selectedProjectId <= 0) return;
-        var start = DateTime.Now.AddMinutes(-minutes);
+        var start = DateTime.UtcNow.AddMinutes(-minutes);
         await TimeEntryService.CreateTimeEntry(new TimeEntryCreateRequest
         {
             ProjectId = selectedProjectId,
             Start = start,
-            End = DateTime.Now
+            End = DateTime.UtcNow
         });
         Snackbar.Add($"{minutes}m logged", Severity.Success);
         await Reload();

--- a/TimeTracker.Playwright/Tests/DesktopNavigationTests.cs
+++ b/TimeTracker.Playwright/Tests/DesktopNavigationTests.cs
@@ -8,6 +8,10 @@ public class DesktopNavigationTests : AuthenticatedDesktopPageTest
     {
         await Page.GotoAsync("/");
         await Expect(Page.Locator(".tt-fab button")).ToBeEnabledAsync(new() { Timeout = 30_000 });
+        // Wait for LoadData() to complete so api/timeentries/active is not in-flight when tests navigate away.
+        // Without this, Chromium aborts the pending fetch and fires Page.RequestFailed.
+        await Expect(Page.GetByText("Tracking now").Or(Page.GetByText("Start a timer")))
+            .ToBeVisibleAsync(new() { Timeout = 15_000 });
     }
 
     private async Task OpenDrawer()

--- a/TimeTracker.Playwright/Tests/NavigationTests.cs
+++ b/TimeTracker.Playwright/Tests/NavigationTests.cs
@@ -12,6 +12,10 @@ public class NavigationTests : AuthenticatedPageTest
         // Admin-role nav links (clients, projects) only render once that resolves — wait for one
         // of them to confirm auth state is settled before any test assertion.
         await Expect(Page.Locator(".bottom-nav").GetByText("Clients")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+        // Wait for LoadData() to complete so api/timeentries/active is not in-flight when tests navigate away.
+        // Without this, Chromium aborts the pending fetch and fires Page.RequestFailed.
+        await Expect(Page.GetByText("Tracking now").Or(Page.GetByText("Start a timer")))
+            .ToBeVisibleAsync(new() { Timeout = 15_000 });
     }
 
     [Test]

--- a/TimeTracker.Playwright/Tests/TimerTests.cs
+++ b/TimeTracker.Playwright/Tests/TimerTests.cs
@@ -8,6 +8,10 @@ public class TimerTests : AuthenticatedPageTest
     {
         await Page.GotoAsync("/");
         await Expect(Page.Locator(".tt-fab button")).ToBeEnabledAsync(new() { Timeout = 30_000 });
+        // Wait for LoadData() to complete so api/timeentries/active is not in-flight when assertions run.
+        // Without this, Chromium aborts the pending fetch and fires Page.RequestFailed.
+        await Expect(Page.GetByText("Tracking now").Or(Page.GetByText("Start a timer")))
+            .ToBeVisibleAsync(new() { Timeout = 15_000 });
     }
 
     [Test]

--- a/TimeTracker.Web/Features/TimeEntries/TimeEntryModels.cs
+++ b/TimeTracker.Web/Features/TimeEntries/TimeEntryModels.cs
@@ -6,7 +6,14 @@ public class TimeEntryMappingConfig : IRegister
 {
     public void Register(TypeAdapterConfig config)
     {
+        // SQL Server datetime2 has no timezone info — EF Core returns Kind=Unspecified.
+        // Explicitly mark as Utc so System.Text.Json serializes with a 'Z' suffix,
+        // letting WASM clients call .ToLocalTime() to get the correct browser-local time.
         config.NewConfig<TimeEntry, TimeEntryResponse>()
+            .Map(dest => dest.Start, src => DateTime.SpecifyKind(src.Start, DateTimeKind.Utc))
+            .Map(dest => dest.End, src => src.End.HasValue
+                ? (DateTime?)DateTime.SpecifyKind(src.End.Value, DateTimeKind.Utc)
+                : null)
             .Map(dest => dest.Project, src => new ProjectSummary(
                 src.Project != null ? src.Project.Id : 0,
                 src.Project != null ? src.Project.Name : string.Empty));


### PR DESCRIPTION
## Summary

- **UTC timezone bug**: Timer displayed ~10h elapsed and entry editor showed wrong time ranges because `datetime2` columns returned from SQL Server have `Kind=Unspecified`. Fixed at the Mapster layer with `DateTime.SpecifyKind(..., DateTimeKind.Utc)` so all times serialized to WASM carry the `Z` suffix. All WASM DateTime usages updated to use `DateTime.UtcNow` for operations and `.ToLocalTime()` for display.
- **Playwright race condition**: Tests that navigated away from the timer page were failing with `Page.RequestFailed` for `api/timeentries/active`. The WASM becomes interactive (enabling the FAB) before `OnInitializedAsync`'s `LoadData()` finishes the fetch — Chromium aborted the in-flight request on navigation. Fixed by adding a wait for `"Tracking now"` or `"Start a timer"` to appear in the three timer-page SetUps.
- **Pre-push hook**: Disabled permanently (replaced with no-op). CLAUDE.md updated to require manual Playwright runs.

## Test plan

- [x] 34/34 Playwright tests pass, 2 write tests skipped as expected
- [x] Rebased on top of RLS PR #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)