### PR TITLE
fix: remove auth status from log (CWE-359)

### DIFF
--- a/TimeTracker.Web/Features/Auth/AuthEndpoints.cs
+++ b/TimeTracker.Web/Features/Auth/AuthEndpoints.cs
@@ -43,7 +43,7 @@ public static class AuthEndpoints
 
             if (result.Status != ExternalLoginStatus.Success)
             {
-                logger.LogWarning("Auth: login failed with status {Status}", result.Status);
+                logger.LogWarning("Auth: login failed — unexpected status from external login service");
                 return Results.Redirect($"/login?error={result.Status.ToString().ToLowerInvariant().Replace("_", "-")}");
             }
 


### PR DESCRIPTION
## Summary

Resolves CodeQL code scanning alert #8 (cs/exposure-of-sensitive-information).

`AuthEndpoints.cs` line 46 was logging `result.Status` (an `ExternalLoginStatus` enum value). CodeQL traced the value back to the `EmailNotAllowed` constant and flagged it as potential exposure of private information (CWE-359).

The `EmailNotAllowed` case is handled separately above with its own log message and early return, but CodeQL's flow analysis doesn't consider the guard sufficient. The status value adds no diagnostic value in the catch-all failure path, so it has been removed from the log message entirely.

## Test plan

- [x] `dotnet build` passes
- [x] 110/110 unit tests pass
- [ ] CodeQL re-scan should clear alert #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)