### PR TITLE
feat: nightly database backup export (#104)

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,74 @@
+name: Database Backup
+
+on:
+  schedule:
+    - cron: '0 2 * * *'   # 02:00 UTC daily
+  workflow_dispatch:
+
+permissions:
+  id-token: write   # required for OIDC login
+  contents: read
+
+jobs:
+  backup:
+    name: Export .bacpac
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Azure Login
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.BACKUP_AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Get runner public IP
+        id: ip
+        run: echo "addr=$(curl -sf https://api.ipify.org)" >> $GITHUB_OUTPUT
+
+      - name: Open SQL firewall for runner
+        run: |
+          az sql server firewall-rule create \
+            --resource-group ${{ vars.BACKUP_RESOURCE_GROUP }} \
+            --server ${{ vars.BACKUP_SQL_SERVER }} \
+            --name github-actions-backup \
+            --start-ip-address ${{ steps.ip.outputs.addr }} \
+            --end-ip-address ${{ steps.ip.outputs.addr }}
+
+      - name: Get Azure AD token for SQL
+        id: token
+        run: |
+          TOKEN=$(az account get-access-token \
+            --resource https://database.windows.net \
+            --query accessToken -o tsv)
+          echo "::add-mask::$TOKEN"
+          echo "value=$TOKEN" >> $GITHUB_OUTPUT
+
+      - name: Install SqlPackage
+        run: dotnet tool install -g microsoft.sqlpackage
+
+      - name: Export .bacpac
+        run: |
+          sqlpackage \
+            /Action:Export \
+            /TargetFile:"backup-$(date +%Y-%m-%d).bacpac" \
+            /SourceServerName:"${{ vars.BACKUP_SQL_SERVER }}.database.windows.net" \
+            /SourceDatabaseName:"${{ vars.BACKUP_SQL_DATABASE }}" \
+            /AccessToken:"${{ steps.token.outputs.value }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: db-backup-${{ github.run_number }}
+          path: "*.bacpac"
+          retention-days: 90
+          if-no-files-found: error
+
+      - name: Close SQL firewall
+        if: always()
+        run: |
+          az sql server firewall-rule delete \
+            --resource-group ${{ vars.BACKUP_RESOURCE_GROUP }} \
+            --server ${{ vars.BACKUP_SQL_SERVER }} \
+            --name github-actions-backup \
+            --yes 2>/dev/null || true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,6 +10,8 @@ TimeTracker is a personal timesheeting application for tracking time entries aga
 
 | Date | Change | PR/Branch |
 |------|--------|-----------|
+| 2026-06 | **Nightly database backup** — GitHub Actions `.bacpac` export via dedicated OIDC SP (custom role: firewall rule write/delete only); 90-day artifact retention | #104 |
+| 2026-06 | **SQL Server Row-Level Security + audit trail** — `UserSessionContextInterceptor` sets `SESSION_CONTEXT(N'UserId')` before every EF Core command; predicate functions filter per-user; `CreatedBy`/`UpdatedBy`/`DeletedBy` audit columns | #130 |
 | 2026-06 | **Global InteractiveWebAssembly** — abandoned SSR+WASM islands hybrid; MudBlazor #9743 prevents interactive layouts in SSR | `feature/wasm-islands` |
 | 2026-06 | Renamed `TimeTracker.Wasm` → `TimeTracker.Client` (Microsoft standard .Client naming) | `feature/wasm-islands` |
 | 2026-06 | Added `TimeTracker.Contracts` — shared DTOs; `CookieAuthenticationStateProvider`; `/api/auth/user` endpoint; `ReportsCalculations` static class; 92 unit tests | `feature/wasm-islands` |
@@ -205,11 +207,12 @@ Application Insights is not included (pay-as-you-go, no free monthly allowance o
 | Live app hosting | Azure App Service F1 | Free — hard limit, no overage possible |
 | Showcase hosting | GitHub Pages | Free |
 | Database | Azure SQL Database free offer | Free — 32 GB, 7-day automated backups, no expiry |
+| Database backup | GitHub Actions nightly `.bacpac` export → 90-day artifact | Free (within 2,000 min/month Actions quota) |
 | Auth | Google OAuth 2.0 via ASP.NET Identity | Free |
 | CI/CD | GitHub Actions — OIDC push-to-deploy | Free |
 | Structured logging | Serilog → stdout (Azure App Service log stream) | Free |
 | Uptime monitoring | UptimeRobot free tier → `/health` endpoint | Free |
-| Tests | 107 service integration tests (EF InMemory) | — |
+| Tests | 110 service integration tests (EF InMemory) | — |
 
 ---
 

--- a/docs/azure-deployment.md
+++ b/docs/azure-deployment.md
@@ -272,55 +272,6 @@ Upgrading to at least the Basic (B1) tier unlocks custom domain binding and App 
 
 ---
 
-## Refreshing the Playwright auth state
-
-The Playwright E2E suite authenticates by replaying a stored browser session. That session is encoded as the `PLAYWRIGHT_AUTH_STATE_B64` GitHub Actions secret. The session cookie has a **1-day expiration** — once it expires, all authenticated tests will fail with a timeout waiting for `.tt-fab button`.
-
-### When to refresh
-
-- After the auth cookie expires (authenticated tests all fail with 30 s timeout on `.tt-fab button`)
-- After a full sign-out or Identity schema change
-
-### Steps
-
-**1 — Start the app locally in Development mode**
-
-```bash
-cd TimeTracker.Web && dotnet run
-```
-
-The dev login endpoint (`/api/dev/login`) is only available in Development mode. The app must be running before step 2.
-
-**2 — Capture fresh auth state**
-
-```bash
-BROWSER= PLAYWRIGHT_BASE_URL=https://localhost:7006 \
-  dotnet test TimeTracker.Playwright \
-  --filter "FullyQualifiedName~CaptureAuthState" \
-  --logger "console;verbosity=normal"
-```
-
-This navigates to `/api/dev/login`, signs in as the first Admin user, waits for WASM to hydrate, and saves the browser session to:
-
-```
-TimeTracker.Playwright/bin/Debug/net10.0/playwright/.auth/user.json
-```
-
-**3 — Update the GitHub secret**
-
-```bash
-cat TimeTracker.Playwright/bin/Debug/net10.0/playwright/.auth/user.json \
-  | base64 -w 0 \
-  | gh secret set PLAYWRIGHT_AUTH_STATE_B64
-```
-
-No copy/paste required — `gh` reads from stdin and updates the secret directly.
-
-**4 — Verify**
-
-Merge any change to `main` (or re-run the Deploy workflow). The Playwright job runs post-deploy and should show all authenticated tests passing.
-
----
 
 ## Database Backup Setup
 

--- a/docs/azure-deployment.md
+++ b/docs/azure-deployment.md
@@ -322,9 +322,111 @@ Merge any change to `main` (or re-run the Deploy workflow). The Playwright job r
 
 ---
 
+## Database Backup Setup
+
+A GitHub Actions workflow (`.github/workflows/backup.yml`) exports a `.bacpac` nightly at 02:00 UTC and stores it as a 90-day artifact. It uses a dedicated service principal with the minimum possible permissions — separate from the deploy SP.
+
+**Credential model:**
+- Separate app registration (`timetracker-github-backup`) from the deploy SP
+- Custom Azure role: only `firewallRules/write` + `firewallRules/delete`, scoped to the SQL server resource
+- SQL user: `db_datareader` + `VIEW DATABASE STATE` + `VIEW DEFINITION` — no `db_owner`
+- OIDC (no client secrets stored anywhere)
+
+### Step A — Create the app registration and service principal
+
+```bash
+az ad app create --display-name "timetracker-github-backup"
+
+BACKUP_APP_ID=$(az ad app list --display-name "timetracker-github-backup" --query "[0].appId" -o tsv)
+BACKUP_APP_OID=$(az ad app list --display-name "timetracker-github-backup" --query "[0].id" -o tsv)
+
+az ad sp create --id $BACKUP_APP_ID
+BACKUP_SP_OID=$(az ad sp show --id $BACKUP_APP_ID --query id -o tsv)
+
+TENANT=$(az account show --query tenantId -o tsv)
+SUB=$(az account show --query id -o tsv)
+```
+
+### Step B — Create a minimal custom Azure role
+
+```bash
+az role definition create --role-definition "{
+  \"Name\": \"TimeTracker Backup Firewall Manager\",
+  \"Description\": \"Adds and removes a single SQL Server firewall rule for the GitHub Actions backup workflow\",
+  \"Actions\": [
+    \"Microsoft.Sql/servers/firewallRules/write\",
+    \"Microsoft.Sql/servers/firewallRules/delete\"
+  ],
+  \"AssignableScopes\": [\"/subscriptions/$SUB\"]
+}"
+```
+
+### Step C — Assign the role, scoped to the SQL server only
+
+```bash
+az role assignment create \
+  --role "TimeTracker Backup Firewall Manager" \
+  --assignee-object-id $BACKUP_SP_OID \
+  --assignee-principal-type ServicePrincipal \
+  --scope /subscriptions/$SUB/resourceGroups/$RG/providers/Microsoft.Sql/servers/$SERVER
+```
+
+This SP can add and remove firewall rules on this one SQL server. It cannot read or modify any other Azure resource.
+
+### Step D — Create the federated credential
+
+```bash
+az ad app federated-credential create \
+  --id $BACKUP_APP_OID \
+  --parameters "{
+    \"name\": \"timetracker-backup-main\",
+    \"issuer\": \"https://token.actions.githubusercontent.com\",
+    \"subject\": \"repo:zkarachiwala/TimeTracker:ref:refs/heads/main\",
+    \"audiences\": [\"api://AzureADTokenExchange\"]
+  }"
+```
+
+### Step E — Create the SQL database user
+
+Connect to `${SERVER}.database.windows.net` with your Azure AD admin account (Azure Data Studio or `sqlcmd`) and run against `TimeTrackerDb`:
+
+```sql
+CREATE USER [timetracker-github-backup] FROM EXTERNAL PROVIDER;
+ALTER ROLE db_datareader ADD MEMBER [timetracker-github-backup];
+GRANT VIEW DATABASE STATE TO [timetracker-github-backup];
+GRANT VIEW DEFINITION TO [timetracker-github-backup];
+```
+
+`VIEW DATABASE STATE` is required by SqlPackage to read internal database state during export.
+`VIEW DEFINITION` is required to read schema object definitions for the `.bacpac`.
+
+### Step F — Add to GitHub
+
+```bash
+echo "BACKUP_AZURE_CLIENT_ID: $BACKUP_APP_ID"
+```
+
+In **Settings → Secrets and variables → Actions** add:
+
+| Type | Name | Value |
+|------|------|-------|
+| Secret | `BACKUP_AZURE_CLIENT_ID` | From above |
+| Variable | `BACKUP_RESOURCE_GROUP` | `timetracker-rg` |
+| Variable | `BACKUP_SQL_SERVER` | `timetracker-sql` |
+| Variable | `BACKUP_SQL_DATABASE` | `TimeTrackerDb` |
+
+`AZURE_TENANT_ID` and `AZURE_SUBSCRIPTION_ID` are reused from the deploy setup.
+
+### Verifying
+
+Run the workflow manually from **Actions → Database Backup → Run workflow**. A `.bacpac` artifact will appear on the run within a few minutes. Check that the firewall rule `github-actions-backup` is absent from the SQL server after the run completes (the cleanup step removes it unconditionally).
+
+---
+
 ## Free tier limits
 
 | Resource | Plan | Limit | When exceeded |
 |----------|------|-------|---------------|
 | App Service | F1 | 60 CPU min/day, 1 GB RAM, sleeps after 20 min idle | Throttled, no charge |
 | Azure SQL | Free offer | 32 GB data, 32 GB backup | Auto-pauses, no charge |
+| GitHub Actions | Free | 2,000 min/month, 500 MB artifact storage | Blocked until next cycle |

--- a/docs/azure-deployment.md
+++ b/docs/azure-deployment.md
@@ -283,9 +283,17 @@ A GitHub Actions workflow (`.github/workflows/backup.yml`) exports a `.bacpac` n
 - SQL user: `db_datareader` + `VIEW DATABASE STATE` + `VIEW DEFINITION` — no `db_owner`
 - OIDC (no client secrets stored anywhere)
 
-### Step A — Create the app registration and service principal
+### Step A — Set variables and create the app registration
+
+These steps are self-contained — you do not need to have run Step 0 first. Set the resource names here:
 
 ```bash
+RG=timetracker-rg
+SERVER=timetracker-sql
+
+SUB=$(az account show --query id -o tsv)
+TENANT=$(az account show --query tenantId -o tsv)
+
 az ad app create --display-name "timetracker-github-backup"
 
 BACKUP_APP_ID=$(az ad app list --display-name "timetracker-github-backup" --query "[0].appId" -o tsv)
@@ -293,9 +301,6 @@ BACKUP_APP_OID=$(az ad app list --display-name "timetracker-github-backup" --que
 
 az ad sp create --id $BACKUP_APP_ID
 BACKUP_SP_OID=$(az ad sp show --id $BACKUP_APP_ID --query id -o tsv)
-
-TENANT=$(az account show --query tenantId -o tsv)
-SUB=$(az account show --query id -o tsv)
 ```
 
 ### Step B — Create a minimal custom Azure role
@@ -339,7 +344,7 @@ az ad app federated-credential create \
 
 ### Step E — Create the SQL database user
 
-Connect to `${SERVER}.database.windows.net` with your Azure AD admin account (Azure Data Studio or `sqlcmd`) and run against `TimeTrackerDb`:
+Connect to `timetracker-sql.database.windows.net` with your Azure AD admin account (Azure Data Studio or `sqlcmd`) and run against `TimeTrackerDb`:
 
 ```sql
 CREATE USER [timetracker-github-backup] FROM EXTERNAL PROVIDER;


### PR DESCRIPTION
## Summary

Closes #104.

Adds `.github/workflows/backup.yml` — a scheduled GitHub Actions workflow that exports a `.bacpac` daily at 02:00 UTC and stores it as a 90-day artifact.

**Credential model (strictly limited):**
- Dedicated OIDC service principal `timetracker-github-backup` — separate from the deploy SP, no client secret
- Custom Azure role `TimeTracker Backup Firewall Manager`: only `Microsoft.Sql/servers/firewallRules/write` + `delete`, scoped to the SQL server resource
- SQL user: `db_datareader` + `VIEW DATABASE STATE` + `VIEW DEFINITION` — no `db_owner`

**Workflow steps:**
1. OIDC login with backup SP
2. Get runner public IP, open SQL firewall for that IP only
3. Get Azure AD access token for `https://database.windows.net`
4. `SqlPackage /Action:Export` → `.bacpac`
5. Upload artifact (90-day retention, `if-no-files-found: error`)
6. Remove firewall rule (`if: always()` — runs even on failure)

## Setup required (one-time manual steps)

See **docs/azure-deployment.md → Database Backup Setup** (Steps A–F) for the full Azure CLI + SQL commands. GitHub secrets/vars needed:

| Type | Name |
|------|------|
| Secret | `BACKUP_AZURE_CLIENT_ID` |
| Variable | `BACKUP_RESOURCE_GROUP` |
| Variable | `BACKUP_SQL_SERVER` |
| Variable | `BACKUP_SQL_DATABASE` |

`AZURE_TENANT_ID` and `AZURE_SUBSCRIPTION_ID` are reused from the deploy setup.

## Test plan

- [ ] Complete Steps A–F in azure-deployment.md
- [ ] Run workflow manually: Actions → Database Backup → Run workflow
- [ ] Confirm `.bacpac` artifact appears on the run
- [ ] Confirm `github-actions-backup` firewall rule is absent from SQL server after run

🤖 Generated with [Claude Code](https://claude.com/claude-code)