### PR TITLE
fix: store backups in private repo, not public artifact

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -48,21 +48,27 @@ jobs:
         run: dotnet tool install -g microsoft.sqlpackage
 
       - name: Export .bacpac
+        id: export
         run: |
+          FILE="backup-$(date +%Y-%m-%d).bacpac"
           sqlpackage \
             /Action:Export \
-            /TargetFile:"backup-$(date +%Y-%m-%d).bacpac" \
+            /TargetFile:"$FILE" \
             /SourceServerName:"${{ vars.BACKUP_SQL_SERVER }}.database.windows.net" \
             /SourceDatabaseName:"${{ vars.BACKUP_SQL_DATABASE }}" \
             /AccessToken:"${{ steps.token.outputs.value }}"
+          echo "file=$FILE" >> $GITHUB_OUTPUT
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: db-backup-${{ github.run_number }}
-          path: "*.bacpac"
-          retention-days: 90
-          if-no-files-found: error
+      - name: Push to private backup repo
+        run: |
+          git clone https://x-access-token:${{ secrets.BACKUP_REPO_TOKEN }}@github.com/${{ github.repository_owner }}/${{ vars.BACKUP_REPO_NAME }}.git backup-repo
+          cp ${{ steps.export.outputs.file }} backup-repo/
+          cd backup-repo
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add .
+          git diff --staged --quiet || git commit -m "backup: ${{ steps.export.outputs.file }}"
+          git push
 
       - name: Close SQL firewall
         if: always()

--- a/docs/azure-deployment.md
+++ b/docs/azure-deployment.md
@@ -358,26 +358,44 @@ ALTER ROLE db_owner ADD MEMBER [timetracker-github-backup];
 
 The Azure RBAC side of this SP is still tightly locked (firewall rule write/delete only, scoped to the SQL server resource) — `db_owner` on the database does not expand that.
 
-### Step F — Add to GitHub
+### Step F — Create the private backup repository
+
+Create a **private** repository at `github.com/zkarachiwala/TimeTracker-backups` (or any name you choose — must be private). Leave it empty; the workflow will push `.bacpac` files to it daily.
+
+### Step G — Create a fine-grained PAT for the backup repo
+
+Go to **GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens → Generate new token**:
+
+| Field | Value |
+|-------|-------|
+| Token name | `TimeTracker backup push` |
+| Expiration | 1 year (maximum for fine-grained PATs — set a calendar reminder to rotate) |
+| Resource owner | `zkarachiwala` |
+| Repository access | Only select repositories → `TimeTracker-backups` |
+| Repository permissions | Contents → **Read and write** (all others: No access) |
+
+### Step H — Add secrets and variables to GitHub
 
 ```bash
 echo "BACKUP_AZURE_CLIENT_ID: $BACKUP_APP_ID"
 ```
 
-In **Settings → Secrets and variables → Actions** add:
+In **Settings → Secrets and variables → Actions** on the `TimeTracker` repo add:
 
 | Type | Name | Value |
 |------|------|-------|
 | Secret | `BACKUP_AZURE_CLIENT_ID` | From above |
+| Secret | `BACKUP_REPO_TOKEN` | Fine-grained PAT from Step G |
 | Variable | `BACKUP_RESOURCE_GROUP` | `timetracker-rg` |
 | Variable | `BACKUP_SQL_SERVER` | `timetracker-sql` |
 | Variable | `BACKUP_SQL_DATABASE` | `TimeTrackerDb` |
+| Variable | `BACKUP_REPO_NAME` | `TimeTracker-backups` (or whatever you named it) |
 
 `AZURE_TENANT_ID` and `AZURE_SUBSCRIPTION_ID` are reused from the deploy setup.
 
 ### Verifying
 
-Run the workflow manually from **Actions → Database Backup → Run workflow**. A `.bacpac` artifact will appear on the run within a few minutes. Check that the firewall rule `github-actions-backup` is absent from the SQL server after the run completes (the cleanup step removes it unconditionally).
+Run the workflow manually from **Actions → Database Backup → Run workflow**. A `.bacpac` file will be committed to the private `TimeTracker-backups` repo. Check that the firewall rule `github-actions-backup` is absent from the SQL server after the run completes (the cleanup step removes it unconditionally).
 
 ---
 

--- a/docs/azure-deployment.md
+++ b/docs/azure-deployment.md
@@ -348,13 +348,15 @@ Connect to `timetracker-sql.database.windows.net` with your Azure AD admin accou
 
 ```sql
 CREATE USER [timetracker-github-backup] FROM EXTERNAL PROVIDER;
-ALTER ROLE db_datareader ADD MEMBER [timetracker-github-backup];
-GRANT VIEW DATABASE STATE TO [timetracker-github-backup];
-GRANT VIEW DEFINITION TO [timetracker-github-backup];
+ALTER ROLE db_owner ADD MEMBER [timetracker-github-backup];
 ```
 
-`VIEW DATABASE STATE` is required by SqlPackage to read internal database state during export.
-`VIEW DEFINITION` is required to read schema object definitions for the `.bacpac`.
+`db_owner` is required for two reasons specific to this database:
+
+1. **SqlPackage needs `DBCC SHOW_STATISTICS`** to analyse indexes during export — this requires `db_owner` or `db_ddladmin`; `db_datareader` alone is insufficient.
+2. **RLS bypasses** — the app schema has Row-Level Security policies that filter data by `SESSION_CONTEXT(N'UserId')`. A backup user has no session context, so a `db_datareader` account would export empty tables. `db_owner` is exempt from RLS by SQL Server design, ensuring the full dataset is captured.
+
+The Azure RBAC side of this SP is still tightly locked (firewall rule write/delete only, scoped to the SQL server resource) — `db_owner` on the database does not expand that.
 
 ### Step F — Add to GitHub
 


### PR DESCRIPTION
## Summary

Two fixes on top of #133:

- **Private repo instead of artifact** — GitHub Actions artifacts on public repos are publicly downloadable. Replaced `upload-artifact` with a `git push` to the private `TimeTracker-backups` repo using a fine-grained PAT scoped to that repo only (contents: write, nothing else).
- **`db_owner` for backup SQL user** — `db_datareader` + `VIEW DATABASE STATE` + `VIEW DEFINITION` was insufficient: SqlPackage requires `DBCC SHOW_STATISTICS` (needs `db_owner`/`db_ddladmin`), and RLS filters out all rows for a user with no session context. `db_owner` bypasses RLS and satisfies SqlPackage. The Azure RBAC side remains tightly locked.

## New secrets/variables required

| Type | Name |
|------|------|
| Secret | `BACKUP_REPO_TOKEN` (fine-grained PAT, `TimeTracker-backups` contents:write only) |
| Variable | `BACKUP_REPO_NAME` = `TimeTracker-backups` |

## Test plan

- [ ] Complete Steps F–H in azure-deployment.md
- [ ] Run workflow manually — `.bacpac` should appear as a commit in `TimeTracker-backups`
- [ ] Confirm firewall rule `github-actions-backup` is absent after run

🤖 Generated with [Claude Code](https://claude.com/claude-code)