### PR TITLE
feat: purge backups older than 30 days

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -64,6 +64,10 @@ jobs:
           git clone https://x-access-token:${{ secrets.BACKUP_REPO_TOKEN }}@github.com/${{ github.repository_owner }}/${{ vars.BACKUP_REPO_NAME }}.git backup-repo
           cp ${{ steps.export.outputs.file }} backup-repo/
           cd backup-repo
+          find . -name "backup-*.bacpac" | while read f; do
+            d=$(basename "$f" .bacpac | sed 's/backup-//')
+            [[ $(date -d "$d" +%s 2>/dev/null) -lt $(date -d "30 days ago" +%s) ]] && rm "$f"
+          done
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           git add .


### PR DESCRIPTION
## Summary

- Adds a cleanup step inside the "Push to private backup repo" job that deletes any `.bacpac` file whose filename date is older than 30 days before committing.
- Keeps the rolling 30-day window in sync each run — no manual intervention needed.
- Deletion is based on the filename date (`backup-YYYY-MM-DD.bacpac`), not git mtime, so it's reliable regardless of when the repo was cloned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)