### PR TITLE
Add DatabaseWarmupMiddleware for Azure SQL cold-start

### DIFF
--- a/TimeTracker.Tests/Infrastructure/DatabaseWarmupMiddlewareTests.cs
+++ b/TimeTracker.Tests/Infrastructure/DatabaseWarmupMiddlewareTests.cs
@@ -1,0 +1,216 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Data.SqlClient;
+using System.Data.Common;
+using TimeTracker.Web.Infrastructure;
+using Xunit;
+
+namespace TimeTracker.Tests.Infrastructure;
+
+[Collection("Services")]
+public class DatabaseWarmupMiddlewareTests
+{
+    private static DefaultHttpContext CreateContext(string? path = null)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Response.Body = new MemoryStream();
+        if (path is not null)
+            ctx.Request.Path = path;
+        return ctx;
+    }
+
+    [Fact]
+    public async Task PassesThroughWhenNextSucceeds()
+    {
+        var nextCalled = false;
+        var context = CreateContext();
+        var middleware = new DatabaseWarmupMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(nextCalled);
+    }
+
+    [Fact]
+    public async Task Returns503HtmlWhenSqlExceptionIsConnectivityError()
+    {
+        var context = CreateContext();
+        var middleware = new DatabaseWarmupMiddleware(_ =>
+            throw CreateSqlException(number: 4060));
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(503, context.Response.StatusCode);
+        Assert.Contains("text/html", context.Response.ContentType);
+        Assert.Contains("Waking up", await ReadResponseBody(context));
+    }
+
+    [Fact]
+    public async Task Returns503ForTimeoutSqlException()
+    {
+        var context = CreateContext();
+        var middleware = new DatabaseWarmupMiddleware(_ =>
+            throw CreateSqlException(number: -2));
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(503, context.Response.StatusCode);
+        Assert.Contains("text/html", context.Response.ContentType);
+    }
+
+    [Fact]
+    public async Task Returns503ForDbException()
+    {
+        var context = CreateContext();
+        var middleware = new DatabaseWarmupMiddleware(_ =>
+            throw new TestDbException());
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(503, context.Response.StatusCode);
+        Assert.Contains("text/html", context.Response.ContentType);
+    }
+
+    [Fact]
+    public async Task Returns503ForInvalidOperationExceptionWithConnectionMessage()
+    {
+        var context = CreateContext();
+        var middleware = new DatabaseWarmupMiddleware(_ =>
+            throw new InvalidOperationException(
+                "An exception has been raised that is likely due to a transient failure. Consider enabling transient error resiliency." +
+                "No connection could be made because the target machine actively refused it."));
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(503, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RethrowsInvalidOperationExceptionWithoutConnectionMessage()
+    {
+        var context = CreateContext();
+        var middleware = new DatabaseWarmupMiddleware(_ =>
+            throw new InvalidOperationException("Some other error"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => middleware.InvokeAsync(context));
+    }
+
+    [Fact]
+    public async Task ReturnsProblemJsonForApiPath()
+    {
+        var context = CreateContext(path: "/api/timeentries/active");
+        var middleware = new DatabaseWarmupMiddleware(_ =>
+            throw CreateSqlException(number: -2));
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(503, context.Response.StatusCode);
+        Assert.Contains("application/problem+json", context.Response.ContentType);
+        var body = await ReadResponseBody(context);
+        Assert.Contains("503", body);
+        Assert.Contains("waking up", body);
+    }
+
+    [Fact]
+    public async Task RethrowsWhenResponseHasAlreadyStarted()
+    {
+        var context = CreateContext();
+        context.Features.Set<IHttpResponseFeature>(new SettableResponseFeature { HasStarted = true });
+
+        var middleware = new DatabaseWarmupMiddleware(_ =>
+            throw CreateSqlException(number: 53));
+
+        await Assert.ThrowsAsync<SqlException>(() => middleware.InvokeAsync(context));
+    }
+
+    [Fact]
+    public async Task RethrowsSqlExceptionWithNonConnectivityNumber()
+    {
+        var context = CreateContext();
+        var middleware = new DatabaseWarmupMiddleware(_ =>
+            throw CreateSqlException(number: 515)); // Cannot insert NULL
+
+        await Assert.ThrowsAsync<SqlException>(() => middleware.InvokeAsync(context));
+    }
+
+    [Fact]
+    public async Task Returns503ForWrappedSqlException()
+    {
+        var context = CreateContext();
+        var middleware = new DatabaseWarmupMiddleware(_ =>
+            throw new InvalidOperationException("outer",
+                CreateSqlException(number: 10054)));
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(503, context.Response.StatusCode);
+        Assert.Contains("text/html", context.Response.ContentType);
+    }
+
+    [Fact]
+    public async Task Returns503ForTransportLevelError()
+    {
+        var context = CreateContext();
+        var middleware = new DatabaseWarmupMiddleware(_ =>
+            throw CreateSqlException(number: 10054));
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(503, context.Response.StatusCode);
+    }
+
+    private static SqlException CreateSqlException(int number, string message = "A network-related error occurred")
+    {
+        var errorCtor = typeof(SqlError).GetConstructor(
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+            [typeof(int), typeof(byte), typeof(byte), typeof(string), typeof(string),
+             typeof(string), typeof(int), typeof(int), typeof(Exception)])!;
+
+        var errors = (SqlErrorCollection)typeof(SqlErrorCollection)
+            .GetConstructor(
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+                [])!
+            .Invoke(null)!;
+
+        var error = (SqlError)errorCtor.Invoke(
+            [number, (byte)0, (byte)0, "server", message, "procedure", 0, 0, null]);
+
+        typeof(SqlErrorCollection).GetMethod("Add",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .Invoke(errors, [error]);
+
+        var sqlExCtor = typeof(SqlException).GetConstructor(
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+            [typeof(string), typeof(SqlErrorCollection), typeof(Exception), typeof(Guid)])!;
+
+        return (SqlException)sqlExCtor.Invoke([message, errors, null, Guid.NewGuid()]);
+    }
+
+    private static async Task<string> ReadResponseBody(HttpContext context)
+    {
+        context.Response.Body.Position = 0;
+        using var reader = new StreamReader(context.Response.Body, leaveOpen: true);
+        return await reader.ReadToEndAsync();
+    }
+
+    private class TestDbException : DbException
+    {
+        public TestDbException() : base("Test database error") { }
+    }
+
+    private class SettableResponseFeature : IHttpResponseFeature
+    {
+        public int StatusCode { get; set; }
+        public string? ReasonPhrase { get; set; }
+        public IHeaderDictionary Headers { get; set; } = new HeaderDictionary();
+        public Stream Body { get; set; } = Stream.Null;
+        public bool HasStarted { get; set; }
+
+        public void OnStarting(Func<object, Task> callback, object state) { }
+        public void OnCompleted(Func<object, Task> callback, object state) { }
+    }
+}

--- a/TimeTracker.Web/Infrastructure/DatabaseWarmupMiddleware.cs
+++ b/TimeTracker.Web/Infrastructure/DatabaseWarmupMiddleware.cs
@@ -1,0 +1,123 @@
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
+
+namespace TimeTracker.Web.Infrastructure;
+
+public class DatabaseWarmupMiddleware(RequestDelegate next)
+{
+    private static readonly string WarmupHtml = """
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Waking up — TimeTracker</title>
+        <style>
+          *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+          body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            background: #f8fafc;
+            color: #334155;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100dvh;
+            padding: 2rem;
+          }
+          .card {
+            max-width: 480px;
+            text-align: center;
+            background: #fff;
+            border-radius: 12px;
+            padding: 2.5rem 2rem;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.08), 0 4px 12px rgba(0,0,0,0.04);
+          }
+          .loader {
+            width: 40px;
+            height: 40px;
+            border: 4px solid #e2e8f0;
+            border-top-color: #6366f1;
+            border-radius: 50%;
+            animation: spin 0.8s linear infinite;
+            margin: 0 auto 1.5rem;
+          }
+          @keyframes spin { to { transform: rotate(360deg); } }
+          h1 { font-size: 1.25rem; font-weight: 600; margin-bottom: 0.5rem; }
+          p { font-size: 0.95rem; line-height: 1.5; color: #64748b; }
+          .note { margin-top: 1.25rem; font-size: 0.825rem; color: #94a3b8; }
+        </style>
+        </head>
+        <body>
+        <div class="card">
+          <div class="loader"></div>
+          <h1>TimeTracker is waking up</h1>
+          <p>The database has been idle and is restarting. This usually takes less than a minute.</p>
+          <p class="note">Please try again in a moment.</p>
+        </div>
+        </body>
+        </html>
+        """;
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await next(context);
+        }
+        catch (Exception ex) when (IsDatabaseUnavailable(ex))
+        {
+            if (context.Response.HasStarted)
+                throw;
+
+            context.Response.Clear();
+            context.Response.StatusCode = 503;
+
+            if (IsApiRequest(context))
+            {
+                context.Response.ContentType = "application/problem+json";
+                await context.Response.WriteAsync("""
+                    {"status":503,"title":"The database is waking up from idle. Please try again in a few seconds.","type":"https://httpstatuses.com/503"}
+                    """);
+            }
+            else
+            {
+                context.Response.ContentType = "text/html; charset=utf-8";
+                await context.Response.WriteAsync(WarmupHtml);
+            }
+        }
+    }
+
+    private static bool IsApiRequest(HttpContext context) =>
+        context.Request.Path.StartsWithSegments("/api", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsDatabaseUnavailable(Exception ex)
+    {
+        var current = ex;
+        while (current is not null)
+        {
+            if (current is SqlException sqlEx)
+            {
+                // Common SQL error numbers for connectivity / wake-up:
+                // -2 = timeout, 2 = network-related, 53 = transport-level,
+                // 4060 = cannot open database, 10054 = connection reset,
+                // 10060 = connection timeout, 11001 = host unknown
+                return sqlEx.Number switch
+                {
+                    -2 or 2 or 53 or 4060 or 10054 or 10060 or 11001 => true,
+                    _ => false
+                };
+            }
+
+            if (current is DbException)
+                return true;
+
+            if (current is InvalidOperationException ioe &&
+                ioe.Message.Contains("connection", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            current = current.InnerException;
+        }
+
+        return false;
+    }
+}

--- a/TimeTracker.Web/Infrastructure/DevEndpointExtensions.cs
+++ b/TimeTracker.Web/Infrastructure/DevEndpointExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Data.SqlClient;
 using TimeTracker.Web.Data;
 using TimeTracker.Web.Dev;
 using TimeTracker.Shared.Entities;
@@ -10,6 +11,10 @@ public static class DevEndpointExtensions
 {
     public static IEndpointRouteBuilder MapDevEndpoints(this IEndpointRouteBuilder app)
     {
+        // Triggers the DatabaseWarmupMiddleware to preview the "waking up" page
+        app.MapGet("/dev/db-wakeup-demo", _ =>
+            throw CreateFakeConnectivityException());
+
         // Signs in the first Admin user — dev/CI only, never deployed to production
         app.MapGet("/api/dev/login", async (
             UserManager<User> userManager,
@@ -49,5 +54,32 @@ public static class DevEndpointExtensions
         }).RequireAuthorization(adminPolicy);
 
         return app;
+    }
+
+    private static SqlException CreateFakeConnectivityException()
+    {
+        var errorCtor = typeof(SqlError).GetConstructor(
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+            [typeof(int), typeof(byte), typeof(byte), typeof(string), typeof(string),
+             typeof(string), typeof(int), typeof(int), typeof(Exception)])!;
+
+        var errors = (SqlErrorCollection)typeof(SqlErrorCollection)
+            .GetConstructor(
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+                [])!
+            .Invoke(null)!;
+
+        var error = errorCtor.Invoke(
+            [4060, (byte)0, (byte)0, "localhost", "Cannot open database \"TimeTrackerDb\". It may be waking from auto-pause.", "", 0, 0, null]);
+
+        typeof(SqlErrorCollection).GetMethod("Add",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .Invoke(errors, [error]);
+
+        var sqlExCtor = typeof(SqlException).GetConstructor(
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+            [typeof(string), typeof(SqlErrorCollection), typeof(Exception), typeof(Guid)])!;
+
+        return (SqlException)sqlExCtor.Invoke(["Database is waking from idle.", errors, null, Guid.NewGuid()]);
     }
 }

--- a/TimeTracker.Web/Program.cs
+++ b/TimeTracker.Web/Program.cs
@@ -88,6 +88,7 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseExceptionHandler();
+app.UseMiddleware<DatabaseWarmupMiddleware>();
 app.UseHsts();
 app.UseHttpsRedirection();
 app.UseMiddleware<SecurityHeadersMiddleware>();


### PR DESCRIPTION
Closes #139

## What

When the Azure SQL database is waking from auto-pause, EF Core throws `SqlException` — this bubbles up through `UseExceptionHandler()` as either a JSON problem details (API) or a broken page (SSR).

This PR adds middleware that catches database connectivity exceptions early and returns:
- **Page requests:** A friendly static HTML page ("TimeTracker is waking up") with 503 status
- **API requests:** A 503 JSON problem details response

## Free-tier safety

- No auto-refresh on the warm-up page — no risk of idle browser tabs burning CPU minutes
- Static HTML string allocated once — zero allocation per request
- No DB access, no background timers, no warm-up pings
- Dev-only `/dev/db-wakeup-demo` endpoint for local testing (never deployed)

## How to test locally

```bash
cd TimeTracker.Web && dotnet run
# Open https://localhost:7006/dev/db-wakeup-demo
```

## Tests

10 unit tests covering: SqlException connectivity numbers, DbException, InvalidOperationException with connection message, wrapped exceptions, non-connectivity SqlException re-throw, API vs page content type, and HasStarted guard.