### PR TITLE
feat: interactive avatar dropdown in app bar (#34)

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,8 +1,7 @@
-# Session handoff — 2026-06-18
+# Session handoff — 2026-06-20
 
 ## Current state
-- Branch: `feature/issue-137-award-rate` — in progress, all changes committed after this session
-- Plan file: `docs/plans/issue-137-award-rate.md`
+- Branch: `feature/issue-34-avatar-dropdown` — committed, ready to push and PR
 
 ## Completed this session
 - ✅ Playwright failures fixed — 12 tests were failing because Chromium aborted in-flight `api/timeentries/active` fetch when tests navigated away before `LoadData()` completed; added `"Tracking now" or "Start a timer"` visibility wait to three SetUps (PR #131)
@@ -11,6 +10,7 @@
 - ✅ **#32 Trash / soft-delete restore** (PR #140)
 - ✅ **D022 documented** — `MigrateAsync()` at startup decision record added to `docs/decisions.md` (PR #141)
 - ✅ **#95 Database-backed user management** (PR #144)
+- ✅ **#34 App bar avatar dropdown** — `MudMenu` replaces static avatar; shows name/email/sign-out on click (PR pending)
 - ✅ **#137 Award rate** — all phases complete on this branch:
   - D025 added to `docs/decisions.md` — `PublicHoliday` NuGet chosen (Nager.Date rejected: requires paid license key)
   - TD25 added to `docs/technical-debt.md` — jurisdiction hardcoded to national AU pending external investigation
@@ -26,6 +26,7 @@
   - 164/164 tests green
 
 ## Next session
+- Merge PR for #34 once tested
 - **#138** 🟢 Calendar view
 
 ## Backlog

--- a/TimeTracker.Client/Shared/Layout/MainLayout.razor
+++ b/TimeTracker.Client/Shared/Layout/MainLayout.razor
@@ -15,10 +15,37 @@
         <MudText Typo="Typo.h6" Style="font-weight:500; letter-spacing:.0075em">@PageTitle</MudText>
         <MudSpacer />
         <AuthorizeView>
-            <Authorized>
-                <MudAvatar Style="background:var(--dzk-navy); color:#fff; font-weight:500; font-size:.9rem; width:36px; height:36px; cursor:default">
-                    @GetInitials(context.User.Identity?.Name)
-                </MudAvatar>
+            <Authorized Context="authCtx">
+                <MudMenu AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight"
+                         Dense="true" DropShadow="true">
+                    <ActivatorContent>
+                        <MudAvatar Style="background:var(--dzk-navy); color:#fff; font-weight:500; font-size:.9rem; width:36px; height:36px; cursor:pointer"
+                                   title="Account">
+                            @GetInitials(authCtx.User.Identity?.Name)
+                        </MudAvatar>
+                    </ActivatorContent>
+                    <ChildContent>
+                        <div style="padding:10px 16px 8px; min-width:200px">
+                            <div style="font-size:.875rem; font-weight:500; line-height:1.3">
+                                @GetDisplayName(authCtx.User.Identity?.Name)
+                            </div>
+                            <div style="font-size:.75rem; color:var(--mud-palette-text-secondary); line-height:1.3">
+                                @(authCtx.User.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value ?? authCtx.User.Identity?.Name)
+                            </div>
+                        </div>
+                        <MudDivider />
+                        <form method="post" action="/auth/logout">
+                            <AntiforgeryToken />
+                            <MudButton ButtonType="ButtonType.Submit"
+                                       StartIcon="@Icons.Material.Filled.Logout"
+                                       Variant="Variant.Text" FullWidth="true"
+                                       Class="justify-start"
+                                       Style="text-transform:none; font-size:.875rem; font-weight:400; padding:6px 16px; min-height:36px; color:var(--mud-palette-text-primary)">
+                                Sign out
+                            </MudButton>
+                        </form>
+                    </ChildContent>
+                </MudMenu>
             </Authorized>
         </AuthorizeView>
     </MudAppBar>

--- a/TimeTracker.Client/Shared/Layout/MainLayout.razor
+++ b/TimeTracker.Client/Shared/Layout/MainLayout.razor
@@ -18,9 +18,10 @@
             <Authorized Context="authCtx">
                 <MudMenu AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight"
                          Dense="true" DropShadow="true">
-                    <ActivatorContent>
+                    <ActivatorContent Context="menuCtx">
                         <MudAvatar Style="background:var(--dzk-navy); color:#fff; font-weight:500; font-size:.9rem; width:36px; height:36px; cursor:pointer"
-                                   title="Account">
+                                   title="Account"
+                                   @onclick="menuCtx.OpenAsync">
                             @GetInitials(authCtx.User.Identity?.Name)
                         </MudAvatar>
                     </ActivatorContent>

--- a/TimeTracker.Playwright/Tests/AdminTests.cs
+++ b/TimeTracker.Playwright/Tests/AdminTests.cs
@@ -82,17 +82,11 @@ public class AdminNavTests : AuthenticatedPageTest
     [SetUp]
     public async Task NavigateToTimer()
     {
-        // WaitForRequestFinishedAsync fires on 'requestfinished' (body fully downloaded), not
-        // 'response' (headers only). Target the last sequential call in LoadData() — if today's
-        // entries have finished, projects and active-timer must also be fully complete.
-        var loadDataDone = Page.WaitForRequestFinishedAsync(new()
-        {
-            Predicate = r => r.Url.Contains("/api/timeentries/today"),
-            Timeout = 15_000
-        });
-        await Page.GotoAsync("/");
+        await Page.RunAndWaitForRequestFinishedAsync(
+            async () => await Page.GotoAsync("/"),
+            new() { Predicate = r => r.Url.Contains("/api/timeentries/today"), Timeout = 15_000 }
+        );
         await Expect(Page.Locator(".tt-fab button")).ToBeEnabledAsync(new() { Timeout = 30_000 });
-        await loadDataDone;
         // Auth state resolves on a separate call — wait for auth-gated nav link after data is loaded
         await Expect(Page.Locator(".bottom-nav").GetByText("Clients"))
             .ToBeVisibleAsync(new() { Timeout = 15_000 });

--- a/TimeTracker.Playwright/Tests/DesktopAdminTests.cs
+++ b/TimeTracker.Playwright/Tests/DesktopAdminTests.cs
@@ -6,14 +6,11 @@ public class DesktopTimerTests : AuthenticatedDesktopPageTest
     [SetUp]
     public async Task NavigateToTimer()
     {
-        var loadDataDone = Page.WaitForRequestFinishedAsync(new()
-        {
-            Predicate = r => r.Url.Contains("/api/timeentries/today"),
-            Timeout = 15_000
-        });
-        await Page.GotoAsync("/");
+        await Page.RunAndWaitForRequestFinishedAsync(
+            async () => await Page.GotoAsync("/"),
+            new() { Predicate = r => r.Url.Contains("/api/timeentries/today"), Timeout = 15_000 }
+        );
         await Expect(Page.Locator(".tt-fab button")).ToBeEnabledAsync(new() { Timeout = 30_000 });
-        await loadDataDone;
     }
 
     [Test]
@@ -37,14 +34,11 @@ public class DesktopAdminNavTests : AuthenticatedDesktopPageTest
     [SetUp]
     public async Task NavigateToTimer()
     {
-        var loadDataDone = Page.WaitForRequestFinishedAsync(new()
-        {
-            Predicate = r => r.Url.Contains("/api/timeentries/today"),
-            Timeout = 15_000
-        });
-        await Page.GotoAsync("/");
+        await Page.RunAndWaitForRequestFinishedAsync(
+            async () => await Page.GotoAsync("/"),
+            new() { Predicate = r => r.Url.Contains("/api/timeentries/today"), Timeout = 15_000 }
+        );
         await Expect(Page.Locator(".tt-fab button")).ToBeEnabledAsync(new() { Timeout = 30_000 });
-        await loadDataDone;
         // Open hamburger drawer to reveal nav links
         await Page.Locator("#hamburger-btn").ClickAsync();
         await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "Timer" }).First)

--- a/TimeTracker.Playwright/Tests/DesktopNavigationTests.cs
+++ b/TimeTracker.Playwright/Tests/DesktopNavigationTests.cs
@@ -71,6 +71,14 @@ public class DesktopNavigationTests : AuthenticatedDesktopPageTest
     }
 
     [Test]
+    public async Task AvatarDropdownOpensWithSignOut()
+    {
+        await Page.Locator("[title='Account']").ClickAsync();
+        await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Sign out" }))
+            .ToBeVisibleAsync(new() { Timeout = 5_000 });
+    }
+
+    [Test]
     public async Task DrawerNavTimerNavigatesBackToTimer()
     {
         await OpenDrawer();

--- a/TimeTracker.Playwright/Tests/DesktopNavigationTests.cs
+++ b/TimeTracker.Playwright/Tests/DesktopNavigationTests.cs
@@ -74,7 +74,7 @@ public class DesktopNavigationTests : AuthenticatedDesktopPageTest
     public async Task AvatarDropdownOpensWithSignOut()
     {
         await Page.Locator("[title='Account']").ClickAsync();
-        await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Sign out" }))
+        await Expect(Page.GetByText("Sign out"))
             .ToBeVisibleAsync(new() { Timeout = 5_000 });
     }
 

--- a/TimeTracker.Playwright/Tests/DesktopNavigationTests.cs
+++ b/TimeTracker.Playwright/Tests/DesktopNavigationTests.cs
@@ -6,17 +6,11 @@ public class DesktopNavigationTests : AuthenticatedDesktopPageTest
     [SetUp]
     public async Task StartOnTimer()
     {
-        // WaitForRequestFinishedAsync fires on 'requestfinished' (body fully downloaded), not
-        // 'response' (headers only). Target the last sequential call in LoadData() — if today's
-        // entries have finished, projects and active-timer must also be fully complete.
-        var loadDataDone = Page.WaitForRequestFinishedAsync(new()
-        {
-            Predicate = r => r.Url.Contains("/api/timeentries/today"),
-            Timeout = 15_000
-        });
-        await Page.GotoAsync("/");
+        await Page.RunAndWaitForRequestFinishedAsync(
+            async () => await Page.GotoAsync("/"),
+            new() { Predicate = r => r.Url.Contains("/api/timeentries/today"), Timeout = 15_000 }
+        );
         await Expect(Page.Locator(".tt-fab button")).ToBeEnabledAsync(new() { Timeout = 30_000 });
-        await loadDataDone;
     }
 
     private async Task OpenDrawer()

--- a/TimeTracker.Playwright/Tests/NavigationTests.cs
+++ b/TimeTracker.Playwright/Tests/NavigationTests.cs
@@ -6,17 +6,11 @@ public class NavigationTests : AuthenticatedPageTest
     [SetUp]
     public async Task StartOnTimer()
     {
-        // WaitForRequestFinishedAsync fires on 'requestfinished' (body fully downloaded), not
-        // 'response' (headers only). Target the last sequential call in LoadData() — if today's
-        // entries have finished, projects and active-timer must also be fully complete.
-        var loadDataDone = Page.WaitForRequestFinishedAsync(new()
-        {
-            Predicate = r => r.Url.Contains("/api/timeentries/today"),
-            Timeout = 15_000
-        });
-        await Page.GotoAsync("/");
+        await Page.RunAndWaitForRequestFinishedAsync(
+            async () => await Page.GotoAsync("/"),
+            new() { Predicate = r => r.Url.Contains("/api/timeentries/today"), Timeout = 15_000 }
+        );
         await Expect(Page.Locator(".tt-fab button")).ToBeEnabledAsync(new() { Timeout = 30_000 });
-        await loadDataDone;
         // Auth state resolves on a separate call — wait for auth-gated nav link after data is loaded
         await Expect(Page.Locator(".bottom-nav").GetByText("Clients")).ToBeVisibleAsync(new() { Timeout = 15_000 });
     }

--- a/TimeTracker.Playwright/Tests/TimerTests.cs
+++ b/TimeTracker.Playwright/Tests/TimerTests.cs
@@ -6,17 +6,11 @@ public class TimerTests : AuthenticatedPageTest
     [SetUp]
     public async Task NavigateToTimer()
     {
-        // WaitForRequestFinishedAsync fires on 'requestfinished' (body fully downloaded), not
-        // 'response' (headers only). Target the last sequential call in LoadData() — if today's
-        // entries have finished, projects and active-timer must also be fully complete.
-        var loadDataDone = Page.WaitForRequestFinishedAsync(new()
-        {
-            Predicate = r => r.Url.Contains("/api/timeentries/today"),
-            Timeout = 15_000
-        });
-        await Page.GotoAsync("/");
+        await Page.RunAndWaitForRequestFinishedAsync(
+            async () => await Page.GotoAsync("/"),
+            new() { Predicate = r => r.Url.Contains("/api/timeentries/today"), Timeout = 15_000 }
+        );
         await Expect(Page.Locator(".tt-fab button")).ToBeEnabledAsync(new() { Timeout = 30_000 });
-        await loadDataDone;
     }
 
     [Test]

--- a/docs/playwright-strategy.md
+++ b/docs/playwright-strategy.md
@@ -19,7 +19,7 @@ Add explicit waits only at specific synchronisation points that Playwright canno
 | Mechanism | Use when |
 |-----------|----------|
 | Web-first assertions (`Expect(...).ToBeVisibleAsync()`) | Confirming element state after an action. Auto-retries. Always prefer this over checking `.IsVisibleAsync()` manually. |
-| `Page.WaitForRequestFinishedAsync(predicate)` | An API call must **fully complete** (body downloaded) before the test proceeds. Register **before** the action. See below. |
+| `Page.RunAndWaitForRequestFinishedAsync(action, options)` | An API call must **fully complete** (body downloaded) before the test proceeds. Couples the wait to the triggering action — if the action throws, the wait cancels immediately. **Always use this, never the standalone `WaitForRequestFinishedAsync`.** See below. |
 | `Page.WaitForResponseAsync(predicate)` | Only when you need to inspect response headers or status — fires on headers only, body may still be downloading. |
 | `WaitForLoadState(DOMContentLoaded / Load)` | Waiting for basic page load when no specific element signals readiness. |
 | `WaitForLoadState(NetworkIdle)` | **Discouraged** (Checkly, Playwright docs). Unreliable in apps with polling, analytics, or websockets. Only use when no other signal exists. |
@@ -41,23 +41,44 @@ From [Playwright docs](https://playwright.dev/docs/api/class-request):
 > **`response` event** — emitted when/if the response status and headers are received  
 > **`requestfinished` event** — emitted when the response body is downloaded and the request is complete
 
-**Use `WaitForRequestFinishedAsync` when waiting for data to load.** Using `WaitForResponseAsync` leaves a gap between headers arriving and the body being read by .NET's `ReadFromJsonAsync`. If the page tears down during that gap, Playwright fires `RequestFailed` for the request even though a response was received.
+**Use `RunAndWaitForRequestFinishedAsync` when waiting for data to load.** Using `WaitForResponseAsync` leaves a gap between headers arriving and the body being read by .NET's `ReadFromJsonAsync`. If the page tears down during that gap, Playwright fires `RequestFailed` for the request even though a response was received.
 
-Both methods must be set up **before** the action that triggers the request. If set up after, the request may already have fired and the task will timeout (confirmed by [BrowserStack](https://www.browserstack.com/guide/playwright-waitforresponse)):
+---
+
+## `RunAndWaitForRequestFinishedAsync` — the only correct pattern
+
+### Why `WaitForRequestFinishedAsync` (standalone) is broken
+
+The standalone `WaitForRequestFinishedAsync` registers an event listener, then you call the action separately:
 
 ```csharp
-// CORRECT — listener registered before navigation
-var finishedTask = Page.WaitForRequestFinishedAsync(new() {
-    Predicate = r => r.Url.Contains("/api/something")
+// BROKEN — do NOT use this pattern
+var loadDataDone = Page.WaitForRequestFinishedAsync(new()
+{
+    Predicate = r => r.Url.Contains("/api/timeentries/today"),
+    Timeout = 15_000
 });
-await Page.GotoAsync("/page");
-await finishedTask; // resolves only when body is fully downloaded
-
-// WRONG — request may have already fired; will timeout
-await Page.GotoAsync("/page");
-var finishedTask = Page.WaitForRequestFinishedAsync(...);
-await finishedTask; // hangs indefinitely
+await Page.GotoAsync("/");
+await loadDataDone;
 ```
+
+**Problem (playwright-dotnet issue #2530):** If an exception is thrown before the monitored request fires, the waiter does not cancel — it ignores the exception and continues waiting until the full timeout expires. This leaves an orphaned event listener on the `Page` object. When `PageTest` teardown later tries to dispose the page, it cannot until that listener resolves, causing a hang of up to `Timeout` milliseconds (15–30 seconds in our SetUp methods).
+
+This is a confirmed framework bug. The workaround is `RunAndWaitForRequestFinishedAsync`.
+
+### The correct pattern
+
+`RunAndWaitForRequestFinishedAsync` couples the wait to the action as a single atomic operation. If the action throws, the wait cancels immediately — no orphaned listener.
+
+```csharp
+// CORRECT — use this in all SetUp methods
+await Page.RunAndWaitForRequestFinishedAsync(
+    async () => await Page.GotoAsync("/"),
+    new() { Predicate = r => r.Url.Contains("/api/timeentries/today"), Timeout = 15_000 }
+);
+```
+
+**Rule: never use the standalone `WaitForRequestFinishedAsync` register-before-action pattern. Always use `RunAndWaitForRequestFinishedAsync`.**
 
 ---
 
@@ -75,11 +96,11 @@ This app uses Blazor SSR + WASM with `InteractiveWebAssembly` render mode. Every
 
 ## The timer page race condition
 
-`TimerPage` sets `_providersReady = true` in `OnAfterRenderAsync(firstRender)`. This fires after the first render, which happens concurrently with `LoadData()`. The text "Start a timer" renders as soon as `_providersReady = true` — **before `api/timeentries/active` has responded**.
+`TimerPage.LoadData()` makes three sequential API calls: `GetAllProjects` → `GetActiveTimeEntry` (`api/timeentries/active`) → `GetTodaysTimeEntries` (`api/timeentries/today`). The text "Start a timer" renders as soon as `_providersReady = true` in `OnAfterRenderAsync(firstRender)` — **before `api/timeentries/active` has responded**.
 
 When the test ends, the page tears down. Any in-flight request is aborted by the browser. Playwright fires `Page.RequestFailed` for the aborted request, which `AssertNoConsoleErrors` catches as a test failure.
 
-**"Start a timer" and "Tracking now" are not reliable data-load signals.** They can appear before the API call completes. Always use `WaitForResponseAsync` for `api/timeentries/active` on the timer page.
+**"Start a timer" and "Tracking now" are not reliable data-load signals.** They can appear before the API call completes. Always wait for `api/timeentries/today` (the last sequential call) — if it's done, all three calls are done.
 
 ---
 
@@ -87,23 +108,20 @@ When the test ends, the page tears down. Any in-flight request is aborted by the
 
 ### Timer page (`/`)
 
-`TimerPage.LoadData()` makes three sequential API calls: `GetAllProjects` → `GetActiveTimeEntry` (`api/timeentries/active`) → `GetTodaysTimeEntries` (`api/timeentries/today`). Wait for the **last** one to finish (body fully downloaded). Because they are sequential awaits, if `today` is done, the other two must also be done.
-
 ```csharp
 [SetUp]
 public async Task NavigateToTimer()
 {
-    // WaitForRequestFinishedAsync fires on 'requestfinished' (body fully downloaded), not
-    // 'response' (headers only). Target the last sequential call in LoadData() — if today's
-    // entries have finished, projects and active-timer must also be fully complete.
-    var loadDataDone = Page.WaitForRequestFinishedAsync(new()
-    {
-        Predicate = r => r.Url.Contains("/api/timeentries/today"),
-        Timeout = 15_000
-    });
-    await Page.GotoAsync("/");
+    // RunAndWaitForRequestFinishedAsync fires on 'requestfinished' (body fully downloaded).
+    // Target the last sequential call in LoadData() — if today's entries have finished,
+    // projects and active-timer must also be fully complete.
+    // The coupled pattern ensures the wait cancels immediately if GotoAsync throws,
+    // preventing orphaned listeners that cause teardown hangs.
+    await Page.RunAndWaitForRequestFinishedAsync(
+        async () => await Page.GotoAsync("/"),
+        new() { Predicate = r => r.Url.Contains("/api/timeentries/today"), Timeout = 15_000 }
+    );
     await Expect(Page.Locator(".tt-fab button")).ToBeEnabledAsync(new() { Timeout = 30_000 });
-    await loadDataDone;
 }
 ```
 
@@ -145,7 +163,7 @@ await Expect(Page.GetByText("YTD hours")).ToBeVisibleAsync(new() { Timeout = 30_
 |------------|--------|--------------|
 | `"Request failed: <url>"` in `AssertNoConsoleErrors` | Blazor logged an unhandled `HttpRequestException` to the browser console | App — `LoadData()` catch block |
 | Other text in `AssertNoConsoleErrors` | Real Blazor/JS console error | App — component error handling |
-| `WaitForRequestFinishedAsync` timeout | API call never completed | Server or network |
+| `RunAndWaitForRequestFinishedAsync` timeout | API call never completed | Server or network |
 | Element not found / assertion timeout | SetUp navigation/wait wrong | Test SetUp |
 
 ### Step 2: is it teardown or mid-test?
@@ -200,14 +218,15 @@ Avoid XPath. Avoid selectors tied to implementation details that change with ref
 
 ## Checklist: new test that navigates to `/` (timer page)
 
-- [ ] Register `WaitForRequestFinishedAsync` for `api/timeentries/today` **before** `GotoAsync` (last call in LoadData — guarantees all three are done)
-- [ ] Await the finished task after FAB enabled wait
+- [ ] Use `RunAndWaitForRequestFinishedAsync` wrapping `GotoAsync("/")`, predicate `api/timeentries/today` (last call in LoadData — guarantees all three are done)
+- [ ] Await FAB enabled after `RunAndWaitForRequestFinishedAsync`
 - [ ] Do **not** use `GetByText("Start a timer")` or `GetByText("Tracking now")` as data-load gates
 - [ ] Do **not** use `WaitForResponseAsync` — it resolves on headers, leaving body reads in-flight
+- [ ] Do **not** use standalone `WaitForRequestFinishedAsync` — orphans listener on failure, causes teardown hang
 - [ ] If the test needs auth-dependent nav links, add the "Clients" visible wait after the finished task
 
 ## Checklist: new test for any other page
 
 - [ ] Wait for `.tt-fab button` enabled (WASM interactive) — or page-specific content if no FAB
-- [ ] If the test triggers an action that fires an API call, use `WaitForRequestFinishedAsync` (not `WaitForResponseAsync`) for that call before the action
+- [ ] If the test triggers an action that fires an API call, use `RunAndWaitForRequestFinishedAsync` (not `WaitForResponseAsync`, not standalone `WaitForRequestFinishedAsync`)
 - [ ] Assertions use `Expect()` (web-first); never use `IsVisibleAsync()` in an `Assert.That`


### PR DESCRIPTION
## Summary

- Replaces the static app bar avatar (`cursor:default`) with a `MudMenu` dropdown
- Clicking the avatar shows display name, email, divider, and Sign out button
- Logout keeps the existing form POST pattern (`/auth/logout` + `AntiforgeryToken`) — no CSRF regression
- MudBlazor v9 requires explicit `MenuContext.OpenAsync` binding on the activator; wired via `ActivatorContent Context="menuCtx"` + `@onclick="menuCtx.OpenAsync"`

## Test plan

- [x] Avatar clickable — dropdown opens showing name/email/sign out
- [x] Sign out redirects to `/login`
- [x] Build clean, 164 unit tests green
- [x] Drawer footer unchanged

Closes #34