### PR TITLE
Calendar view: monthly time entry overview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,16 @@ All changes must follow this workflow:
 
 Never merge a PR without explicit user instruction to do so. Confirming checks pass is not approval to merge. After opening a PR, stop and tell the user it's ready.
 
+## Change Authorization
+
+Never modify code without explicit user authorization. Planning, research, and questions are fine — but do not write, edit, or delete files until the user explicitly says to proceed. A conversational lead-in ("go", "let's go", "do it") is not authorization. The user must give a clear instruction like "make the change", "implement this", or "go ahead and build it."
+
+This applies to all modes (planning, building, debugging, etc.). When in planning mode, present the plan and wait for explicit approval before writing any code.
+
+## App Execution
+
+Never run the application (`dotnet run`) or start any long-running process without explicit user instruction. Do not run `dotnet watch`, launch profiles, or any command that binds to ports or starts a server. Build and test commands are allowed, but anything that starts the app is not.
+
 ## Testing
 
 - Run `dotnet test TimeTracker.sln --configuration Release` before every push. Never push with failing tests.

--- a/TimeTracker.Client/Features/TimeEntries/Components/CalendarView.razor
+++ b/TimeTracker.Client/Features/TimeEntries/Components/CalendarView.razor
@@ -1,0 +1,94 @@
+@using TimeTracker.Client.Features.TimeEntries.Services
+
+<MudTotalCalendar T="TimeEntryCalendarItem"
+                  Values="Totals"
+                  CellClicked="OnCellClicked"
+                  CurrentDay="CurrentMonth"
+                  CurrentDayChanged="OnCurrentDayChanged"
+                  ShowDayTotal="true"
+                  ShowWeekTotal="true"
+                  ShowMonthTotal="true"
+                  ShowToolbar="true"
+                  ShowPrevNextButtons="true"
+                  ShowDatePicker="true"
+                  ShowTodayButton="true"
+                  MonthCellMinHeight="90">
+    <TotalTemplate>
+        <MudTooltip Arrow="true" Placement="Placement.Top">
+            <ChildContent>
+                <div class="mud-cal-total" style="cursor:pointer"
+                     @onclick="() => OnBarClicked(context)" @onclick:stopPropagation="true">
+                    <div class="mud-cal-total-name" style="font-weight:600">@context.Definition.Name</div>
+                    <div class="mud-cal-total-value">@DurationText(context.Amount)</div>
+                </div>
+            </ChildContent>
+            <TooltipContent>
+                <div style="text-align:left; line-height:1.5; min-width:180px">
+                    <div style="font-weight:600; margin-bottom:6px">
+                        @TooltipLabel(context)
+                    </div>
+                    @if (GetTooltipData(context) is { } data)
+                    {
+                        @foreach (var entry in data.Entries)
+                        {
+                            <div style="opacity:.85; display:flex; gap:12px; justify-content:space-between">
+                                <span>@entry.TimeRange</span>
+                                <span style="tabnum">@entry.Duration</span>
+                            </div>
+                        }
+                        <div style="margin-top:6px; padding-top:6px; border-top:1px solid rgba(255,255,255,.2); font-weight:600; display:flex; gap:12px; justify-content:space-between">
+                            <span>Total</span>
+                            <span style="tabnum">@DurationText(context.Amount)</span>
+                        </div>
+                    }
+                </div>
+            </TooltipContent>
+        </MudTooltip>
+    </TotalTemplate>
+</MudTotalCalendar>
+
+@code {
+    [Parameter] public List<Value> Totals { get; set; } = [];
+    [Parameter] public Dictionary<(DateTime Date, string ProjectName), ValueTooltipData>? TooltipLookup { get; set; }
+    [Parameter] public DateTime CurrentMonth { get; set; } = DateTime.Today;
+    [Parameter] public EventCallback<DateTime> CurrentMonthChanged { get; set; }
+    [Parameter] public EventCallback<DateTime> OnDaySelected { get; set; }
+    [Parameter] public EventCallback<(DateTime Date, int ProjectId)> OnProjectClicked { get; set; }
+
+    private async Task OnCellClicked(DateTime date)
+    {
+        await OnDaySelected.InvokeAsync(date);
+    }
+
+    private async Task OnBarClicked(Value value)
+    {
+        if (TooltipLookup != null &&
+            TooltipLookup.TryGetValue((value.Date, value.Definition.Name), out var data))
+        {
+            await OnProjectClicked.InvokeAsync((value.Date, data.ProjectId));
+        }
+    }
+
+    private async Task OnCurrentDayChanged(DateTime newDay)
+    {
+        await CurrentMonthChanged.InvokeAsync(newDay);
+    }
+
+    private ValueTooltipData? GetTooltipData(Value value)
+    {
+        return TooltipLookup?.GetValueOrDefault((value.Date, value.Definition.Name));
+    }
+
+    private string TooltipLabel(Value value)
+    {
+        var data = GetTooltipData(value);
+        if (data?.ClientName != null)
+            return $"{data.ClientName} — {data.ProjectName}";
+        return data?.ProjectName ?? value.Definition.Name;
+    }
+
+    private static string DurationText(double seconds) =>
+        TimeSpan.FromSeconds(seconds).TotalHours >= 1
+            ? $"{(int)TimeSpan.FromSeconds(seconds).TotalHours}h {TimeSpan.FromSeconds(seconds).Minutes}m"
+            : $"{TimeSpan.FromSeconds(seconds).Minutes}m";
+}

--- a/TimeTracker.Client/Features/TimeEntries/Pages/TimeEntriesPage.razor
+++ b/TimeTracker.Client/Features/TimeEntries/Pages/TimeEntriesPage.razor
@@ -4,12 +4,13 @@
 @inject IProjectService ProjectService
 @inject NavigationManager Nav
 @using TimeTracker.Client.Features.TimeEntries.Components
+@using TimeTracker.Client.Features.TimeEntries.Services
 
 <PageTitle>Entries — TimeTracker</PageTitle>
 
 @* ── Filter tabs ── *@
 <div class="tt-filter-tabs">
-    @foreach (var (label, index) in new[] { ("Day", 0), ("Month", 1), ("Year", 2), ("Project", 3) })
+    @foreach (var (label, index) in new[] { ("Day", 0), ("Month", 1), ("Year", 2), ("Project", 3), ("Calendar", 4) })
     {
         var i = index;
         <button class="tt-filter-tab @(activeTab == i ? "active" : "")"
@@ -20,34 +21,61 @@
 </div>
 
 <div class="pa-4">
-    @* ── Range stepper or project picker ── *@
-    @if (activeTab == 3 && _providersReady)
+    @* ── Calendar view ── *@
+    @if (activeTab == 4)
     {
-        <MudSelect T="int" Label="Project" @bind-Value="selectedProjectId"
-                   Variant="Variant.Outlined" Class="mb-4"
-                   AnchorOrigin="Origin.BottomCenter">
-            <MudSelectItem Value="0">All projects</MudSelectItem>
-            @foreach (var p in projects)
-            {
-                <MudSelectItem Value="p.Id">@p.Name</MudSelectItem>
-            }
-        </MudSelect>
+        <CalendarView Totals="_calendarValues"
+                       TooltipLookup="_tooltipLookup"
+                       CurrentMonth="cursor"
+                       CurrentMonthChanged="HandleMonthChanged"
+                       OnDaySelected="HandleDaySelected"
+                       OnProjectClicked="HandleProjectClicked" />
     }
     else
     {
-        <MudCard Class="mb-4" Style="border-radius:10px" Outlined="true">
-            <div class="d-flex align-center justify-space-between pa-1 pl-3">
-                <MudIconButton Icon="@Icons.Material.Filled.ChevronLeft" OnClick="StepBack" />
-                <MudText Typo="Typo.subtitle1" Style="font-weight:500; text-align:center; flex:1">
-                    @RangeLabel
-                </MudText>
-                <MudIconButton Icon="@Icons.Material.Filled.ChevronRight" OnClick="StepForward" />
-            </div>
-        </MudCard>
-    }
+        @* ── Project filter for Day tab ── *@
+        @if (activeTab == 0 && _providersReady)
+        {
+            <MudSelect T="int" Label="Project" @bind-Value="selectedProjectId"
+                       Variant="Variant.Outlined" Class="mb-4"
+                       AnchorOrigin="Origin.BottomCenter"
+                       Clearable="true">
+                <MudSelectItem Value="0">All projects</MudSelectItem>
+                @foreach (var p in projects)
+                {
+                    <MudSelectItem Value="p.Id">@p.Name</MudSelectItem>
+                }
+            </MudSelect>
+        }
 
-    @* ── Summary card ── *@
-    <MudCard Class="summary-card mb-4">
+        @* ── Range stepper or project picker ── *@
+        @if (activeTab == 3 && _providersReady)
+        {
+            <MudSelect T="int" Label="Project" @bind-Value="selectedProjectId"
+                       Variant="Variant.Outlined" Class="mb-4"
+                       AnchorOrigin="Origin.BottomCenter">
+                <MudSelectItem Value="0">All projects</MudSelectItem>
+                @foreach (var p in projects)
+                {
+                    <MudSelectItem Value="p.Id">@p.Name</MudSelectItem>
+                }
+            </MudSelect>
+        }
+        else
+        {
+            <MudCard Class="mb-4" Style="border-radius:10px" Outlined="true">
+                <div class="d-flex align-center justify-space-between pa-1 pl-3">
+                    <MudIconButton Icon="@Icons.Material.Filled.ChevronLeft" OnClick="StepBack" />
+                    <MudText Typo="Typo.subtitle1" Style="font-weight:500; text-align:center; flex:1">
+                        @RangeLabel
+                    </MudText>
+                    <MudIconButton Icon="@Icons.Material.Filled.ChevronRight" OnClick="StepForward" />
+                </div>
+            </MudCard>
+        }
+
+        @* ── Summary card ── *@
+        <MudCard Class="summary-card mb-4">
         <MudCardContent Class="d-flex justify-space-between align-center" Style="padding:14px 18px">
             <div>
                 <MudText Typo="Typo.overline" Style="color:rgba(255,255,255,.7)">Total tracked</MudText>
@@ -99,6 +127,7 @@
             </div>
         }
     }
+    }
 </div>
 
 <div class="bottom-nav-spacer"></div>
@@ -123,7 +152,10 @@
 
     private List<TimeEntryResponse> filteredEntries => activeTab switch
     {
-        0 => allEntries.Where(e => e.Start.Date == cursor.Date).OrderByDescending(e => e.Start).ToList(),
+        0 => allEntries
+            .Where(e => e.Start.Date == cursor.Date)
+            .Where(e => selectedProjectId == 0 || e.Project.Id == selectedProjectId)
+            .OrderByDescending(e => e.Start).ToList(),
         1 => allEntries.Where(e => e.Start.Month == cursor.Month && e.Start.Year == cursor.Year).OrderByDescending(e => e.Start).ToList(),
         2 => allEntries.Where(e => e.Start.Year == cursor.Year).OrderByDescending(e => e.Start).ToList(),
         _ => (selectedProjectId == 0
@@ -199,9 +231,45 @@
         await base.OnAfterRenderAsync(firstRender);
     }
 
+    private List<Value> _calendarValues => CalendarDataTransformer.ToDailyProjectValues(allEntries);
+
+    private Dictionary<(DateTime Date, string ProjectName), ValueTooltipData> _tooltipLookup =>
+        CalendarDataTransformer.ToTooltipLookup(allEntries, _projectClientNames);
+
+    private Dictionary<int, string> _projectClientNames =>
+        projects.ToDictionary(p => p.Id, p => p.ClientName ?? "");
+
     private async Task LoadEntries()
     {
         allEntries = await TimeEntryService.GetAllTimeEntriesByYear(cursor.Year);
+    }
+
+    private async Task HandleDaySelected(DateTime date)
+    {
+        cursor = date;
+        activeTab = 0;
+        await Task.CompletedTask;
+    }
+
+    private async Task HandleMonthChanged(DateTime newMonth)
+    {
+        if (newMonth.Year != cursor.Year)
+        {
+            cursor = newMonth;
+            await LoadEntries();
+        }
+        else
+        {
+            cursor = newMonth;
+        }
+    }
+
+    private async Task HandleProjectClicked((DateTime Date, int ProjectId) args)
+    {
+        cursor = args.Date;
+        selectedProjectId = args.ProjectId;
+        activeTab = 0;
+        await Task.CompletedTask;
     }
 
     private async Task StepBack()

--- a/TimeTracker.Client/Features/TimeEntries/Services/CalendarDataTransformer.cs
+++ b/TimeTracker.Client/Features/TimeEntries/Services/CalendarDataTransformer.cs
@@ -1,0 +1,121 @@
+using Heron.MudCalendar;
+using Heron.MudTotalCalendar;
+using TimeTracker.Client.Shared;
+using TimeTracker.Contracts.Features.TimeEntries;
+
+namespace TimeTracker.Client.Features.TimeEntries.Services;
+
+public static class CalendarDataTransformer
+{
+    public static List<TimeEntryCalendarItem> ToCalendarItems(List<TimeEntryResponse> entries)
+    {
+        return entries.Select(e => new TimeEntryCalendarItem
+        {
+            EntryId = e.Id,
+            ProjectId = e.Project.Id,
+            Start = e.Start,
+            End = e.End,
+            Text = e.Project.Name,
+            ProjectName = e.Project.Name,
+            Note = e.Note
+        }).ToList();
+    }
+
+    public static List<Value> ToDailyProjectValues(List<TimeEntryResponse> entries)
+    {
+        var definitions = new Dictionary<int, ValueDefinition>();
+        var values = new List<Value>();
+
+        foreach (var group in entries
+            .Where(e => e.End.HasValue)
+            .GroupBy(e => e.Start.Date))
+        {
+            var date = group.Key;
+
+            foreach (var projectGroup in group.GroupBy(e => e.Project.Id))
+            {
+                if (!definitions.TryGetValue(projectGroup.Key, out var def))
+                {
+                    var projectName = projectGroup.First().Project.Name;
+                    var color = ProjectColors.ForProject(projectGroup.Key);
+                    def = new ValueDefinition
+                    {
+                        Name = projectName,
+                        Units = "",
+                        FormatString = "",
+                        FormatFunc = seconds =>
+                        {
+                            var ts = TimeSpan.FromSeconds(seconds);
+                            return ts.TotalHours >= 1
+                                ? $"{(int)ts.TotalHours}h {ts.Minutes}m"
+                                : $"{ts.Minutes}m";
+                        },
+                        Style = $"background-color:{color};color:#fff;border-radius:3px;padding:0 4px;font-size:12px"
+                    };
+                    definitions[projectGroup.Key] = def;
+                }
+
+                var totalSeconds = projectGroup.Sum(e => (e.End!.Value - e.Start).TotalSeconds);
+
+                values.Add(new Value
+                {
+                    Date = date,
+                    Definition = def,
+                    Amount = totalSeconds
+                });
+            }
+        }
+
+        return values;
+    }
+
+    public static List<TimeEntryCalendarItem> ToCalendarItemsForDay(List<TimeEntryResponse> entries, DateTime date)
+    {
+        return entries
+            .Where(e => e.Start.Date == date.Date)
+            .Select(e => new TimeEntryCalendarItem
+            {
+                EntryId = e.Id,
+                ProjectId = e.Project.Id,
+                Start = e.Start,
+                End = e.End,
+                Text = e.Project.Name,
+                ProjectName = e.Project.Name,
+                Note = e.Note
+            }).ToList();
+    }
+
+    public static Dictionary<(DateTime Date, string ProjectName), ValueTooltipData> ToTooltipLookup(
+        List<TimeEntryResponse> entries,
+        Dictionary<int, string>? projectClientNames = null)
+    {
+        var lookup = new Dictionary<(DateTime, string), ValueTooltipData>();
+
+        foreach (var entry in entries.Where(e => e.End.HasValue))
+        {
+            var key = (entry.Start.Date, entry.Project.Name);
+            if (!lookup.TryGetValue(key, out var data))
+            {
+                var clientName = projectClientNames?.GetValueOrDefault(entry.Project.Id);
+                data = new ValueTooltipData
+                {
+                    ProjectId = entry.Project.Id,
+                    ProjectName = entry.Project.Name,
+                    ClientName = clientName
+                };
+                lookup[key] = data;
+            }
+
+            var ts = entry.End!.Value - entry.Start;
+            data.Entries.Add(new ValueTooltipData.EntryBreakdown
+            {
+                TimeRange = $"{entry.Start:t} — {entry.End.Value:t}",
+                Duration = ts.TotalHours >= 1
+                    ? $"{(int)ts.TotalHours}h {ts.Minutes}m"
+                    : $"{ts.Minutes}m"
+            });
+        }
+
+        return lookup;
+    }
+}

--- a/TimeTracker.Client/Features/TimeEntries/Services/TimeEntryCalendarItem.cs
+++ b/TimeTracker.Client/Features/TimeEntries/Services/TimeEntryCalendarItem.cs
@@ -1,0 +1,27 @@
+using Heron.MudCalendar;
+
+namespace TimeTracker.Client.Features.TimeEntries.Services;
+
+public class TimeEntryCalendarItem : CalendarItem
+{
+    public int EntryId { get; set; }
+    public int ProjectId { get; set; }
+    public string ProjectName { get; set; } = string.Empty;
+    public string? Note { get; set; }
+
+    public string DurationDisplay
+    {
+        get
+        {
+            if (!End.HasValue) return "running";
+            var ts = End.Value - Start;
+            return ts.TotalHours >= 1
+                ? $"{(int)ts.TotalHours}h {ts.Minutes}m"
+                : $"{ts.Minutes}m";
+        }
+    }
+
+    public string TimeDisplay => End.HasValue
+        ? $"{Start:t} — {End.Value:t}"
+        : $"{Start:t} — now";
+}

--- a/TimeTracker.Client/Features/TimeEntries/Services/ValueTooltipData.cs
+++ b/TimeTracker.Client/Features/TimeEntries/Services/ValueTooltipData.cs
@@ -1,0 +1,15 @@
+namespace TimeTracker.Client.Features.TimeEntries.Services;
+
+public class ValueTooltipData
+{
+    public int ProjectId { get; init; }
+    public string ProjectName { get; init; } = string.Empty;
+    public string? ClientName { get; init; }
+    public List<EntryBreakdown> Entries { get; init; } = [];
+
+    public class EntryBreakdown
+    {
+        public string TimeRange { get; init; } = string.Empty;
+        public string Duration { get; init; } = string.Empty;
+    }
+}

--- a/TimeTracker.Client/Mock/MockDataStore.cs
+++ b/TimeTracker.Client/Mock/MockDataStore.cs
@@ -74,6 +74,13 @@ public class MockDataStore
         // 2 days ago
         entries.Add(E(2, today.AddDays(-2).AddHours(10), 120));
 
+        // 3 days ago
+        entries.Add(E(1, today.AddDays(-3).AddHours(8),  180));
+        entries.Add(E(3, today.AddDays(-3).AddHours(13),  90));
+
+        // 4 days ago (weekend — lighter)
+        entries.Add(E(1, today.AddDays(-4).AddHours(10),  60));
+
         // 5 days ago
         entries.Add(E(1, today.AddDays(-5).AddHours(9),  180));
         entries.Add(E(3, today.AddDays(-5).AddHours(14), 120));
@@ -82,9 +89,17 @@ public class MockDataStore
         entries.Add(E(2, today.AddDays(-7).AddHours(10), 150, "INV-2026-005"));
         entries.Add(E(3, today.AddDays(-7).AddHours(14),  90));
 
+        // 8 days ago
+        entries.Add(E(1, today.AddDays(-8).AddHours(9),  120));
+        entries.Add(E(2, today.AddDays(-8).AddHours(14),  60));
+
         // 10 days ago
         entries.Add(E(1, today.AddDays(-10).AddHours(9),  90));
         entries.Add(E(4, today.AddDays(-10).AddHours(11), 60));
+
+        // 12 days ago
+        entries.Add(E(3, today.AddDays(-12).AddHours(9),  180));
+        entries.Add(E(1, today.AddDays(-12).AddHours(14),  90));
 
         // 14 days ago
         entries.Add(E(2, today.AddDays(-14).AddHours(9),  180, "INV-2026-005"));

--- a/TimeTracker.Client/TimeTracker.Client.csproj
+++ b/TimeTracker.Client/TimeTracker.Client.csproj
@@ -9,6 +9,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
     <PackageReference Include="MudBlazor" Version="9.5.0" />
+    <PackageReference Include="Heron.MudCalendar" Version="4.0.0" />
+    <PackageReference Include="Heron.MudTotalCalendar" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../TimeTracker.Contracts/TimeTracker.Contracts.csproj" />

--- a/TimeTracker.Client/_Imports.razor
+++ b/TimeTracker.Client/_Imports.razor
@@ -19,3 +19,5 @@
 @using TimeTracker.Client.Shared.Theme
 @using TimeTracker.Client.Shared.Components
 @using TimeTracker.Client.Shared.Layout
+@using Heron.MudCalendar
+@using Heron.MudTotalCalendar

--- a/TimeTracker.Playwright/Tests/TimeEntriesTests.cs
+++ b/TimeTracker.Playwright/Tests/TimeEntriesTests.cs
@@ -6,7 +6,10 @@ public class TimeEntriesTests : AuthenticatedPageTest
     [SetUp]
     public async Task NavigateToEntries()
     {
-        await Page.GotoAsync("/entries");
+        await Page.RunAndWaitForRequestFinishedAsync(
+            async () => await Page.GotoAsync("/entries"),
+            new() { Predicate = r => r.Url.Contains("/api/timeentries/year"), Timeout = 15_000 }
+        );
         await Expect(Page.Locator(".tt-fab button")).ToBeEnabledAsync(new() { Timeout = 30_000 });
     }
 

--- a/TimeTracker.Playwright/Tests/TimeEntriesTests.cs
+++ b/TimeTracker.Playwright/Tests/TimeEntriesTests.cs
@@ -13,7 +13,7 @@ public class TimeEntriesTests : AuthenticatedPageTest
     [Test]
     public async Task FilterTabsAreVisible()
     {
-        foreach (var tab in new[] { "Day", "Month", "Year", "Project" })
+        foreach (var tab in new[] { "Day", "Month", "Year", "Project", "Calendar" })
         {
             await Expect(Page.GetByRole(AriaRole.Button, new() { Name = tab })).ToBeVisibleAsync();
         }
@@ -61,5 +61,35 @@ public class TimeEntriesTests : AuthenticatedPageTest
         await Page.GetByRole(AriaRole.Button, new() { Name = "Project" }).ClickAsync();
         await Expect(Page.Locator("label").Filter(new() { HasText = "Project" }))
             .ToBeVisibleAsync(new() { Timeout = 5_000 });
+    }
+
+    [Test]
+    public async Task CalendarTabRendersMonthGrid()
+    {
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Calendar" }).ClickAsync();
+        await Expect(Page.Locator(".mud-cal-month-cell").First)
+            .ToBeVisibleAsync(new() { Timeout = 10_000 });
+    }
+
+    [Test]
+    public async Task CalendarTabHasValueBars()
+    {
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Calendar" }).ClickAsync();
+        var bar = Page.Locator(".mud-cal-total-name").First;
+        await Expect(bar).ToBeVisibleAsync(new() { Timeout = 10_000 });
+        await Expect(bar).Not.ToBeEmptyAsync();
+    }
+
+    [Test]
+    public async Task ClickCalendarDayCellSwitchesToDayTab()
+    {
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Calendar" }).ClickAsync();
+        await Expect(Page.Locator(".mud-cal-month-link").First)
+            .ToBeVisibleAsync(new() { Timeout = 10_000 });
+
+        await Page.Locator(".mud-cal-month-link").First.ClickAsync();
+
+        // Day tab should now be active — summary card should be visible
+        await Expect(Page.GetByText("Total tracked")).ToBeVisibleAsync(new() { Timeout = 10_000 });
     }
 }

--- a/TimeTracker.Playwright/Tests/TimeEntriesTests.cs
+++ b/TimeTracker.Playwright/Tests/TimeEntriesTests.cs
@@ -78,7 +78,7 @@ public class TimeEntriesTests : AuthenticatedPageTest
     public async Task CalendarTabHasValueBars()
     {
         await Page.GetByRole(AriaRole.Button, new() { Name = "Calendar" }).ClickAsync();
-        var bar = Page.Locator(".mud-cal-total-name").First;
+        var bar = Page.Locator(".mud-cal-total-value").First;
         await Expect(bar).ToBeVisibleAsync(new() { Timeout = 10_000 });
         await Expect(bar).Not.ToBeEmptyAsync();
     }

--- a/TimeTracker.Playwright/playwright.runsettings
+++ b/TimeTracker.Playwright/playwright.runsettings
@@ -2,5 +2,6 @@
   <NUnit>
     <StopOnError>true</StopOnError>
     <NumberOfTestWorkers>1</NumberOfTestWorkers>
+    <DefaultTimeout>120000</DefaultTimeout>
   </NUnit>
 </RunSettings>

--- a/TimeTracker.Web/wwwroot/css/app.css
+++ b/TimeTracker.Web/wwwroot/css/app.css
@@ -264,3 +264,26 @@ label.mud-input-label.mud-input-label-animated.mud-input-label-inputcontrol {
     background: rgba(31,172,242,0.14) !important;
     color: #0a6ea3 !important;
 }
+
+/* ── Calendar: prevent day-number link from consuming full cell height ── */
+.mud-cal-month-link {
+    height: auto !important;
+}
+
+/* ── Calendar: value bars stack below day number ── */
+.mud-cal-month-cell-header {
+    padding: 2px 4px;
+}
+
+/* ── Calendar: hide totals column on mobile ── */
+@media (max-width: 768px) {
+    .mud-cal-total-cell {
+        display: none !important;
+    }
+    .mud-cal-month-grid-header .mud-cal-month-header:last-child {
+        display: none !important;
+    }
+    .mud-cal-month-cell:not(.mud-cal-total-cell) {
+        width: calc(100% / 7) !important;
+    }
+}

--- a/docs/plans/issue-138-calendar-view.md
+++ b/docs/plans/issue-138-calendar-view.md
@@ -1,0 +1,359 @@
+# Issue #138 — Calendar View: Monthly Time Entry Overview
+
+## Library Recommendation: `Heron.MudTotalCalendar`
+
+**NuGet:** `Heron.MudTotalCalendar` (v4.0.0, MIT license, 12k+ downloads)
+
+### Why this library
+
+- **Purpose-built**: "A calendar component for displaying numerical data with totals" — exactly matches the requirement of showing daily hour totals in a monthly grid.
+- **MudBlazor native**: Built on top of `Heron.MudCalendar`, which is a MudBlazor calendar component (321 stars, 488k downloads). Inherits MudBlazor theming, dark mode, responsive layout.
+- **Free tier**: MIT license. No paid tiers.
+- **.NET 8+ compatible**: v4.x works with .NET 8/9/10.
+- **Key features for this issue**:
+  - Monthly calendar grid (also supports week, work week, day views)
+  - Each day cell can display multiple numeric values with different colors/styles
+  - Built-in day/week/month totals with `ShowDayTotal`, `ShowWeekTotal`, `ShowMonthTotal`
+  - `CellTemplate` for fully custom day cell rendering (e.g., show project breakdowns)
+  - `TotalTemplate` for custom total display formatting
+  - Built-in month navigation (prev/next)
+  - Click handlers on cells available via `CalendarItem` events
+- **Dependencies**: `Heron.MudCalendar` (also MIT) + `MudBlazor` (already in project)
+
+### Why not alternatives
+
+| Library | Reason rejected |
+|---------|----------------|
+| Syncfusion.Blazor.Schedule | Commercial license (community license has usage limits) |
+| BlazorCalendar (tossnet) | Fewer features, no total-calendar mode, less actively maintained |
+| BlazorFullCalendar | JS interop wrapper, not MudBlazor-native |
+| Smart.Blazor | Large component suite, not free |
+
+---
+
+## Design Decision: Supplement, Not Replace
+
+The calendar view will be a **5th filter tab** alongside Day/Month/Year/Project. The existing list view is useful for detailed scrolling and editing — the calendar adds an at-a-glance overview. Users choose the best mode for their current task.
+
+### Benefits of this approach
+- No new route needed (stays on `/entries`)
+- Shares all data loading, error handling, FAB, and EntrySheet from existing page
+- Users can switch between calendar and list views instantly
+- Zero breaking changes to existing UX
+
+---
+
+## Data Flow
+
+```
+TimeEntriesPage.razor
+    │
+    ├── LoadEntries()
+    │       └── TimeEntryService.GetAllTimeEntriesByYear(cursor.Year)
+    │               └── GET /api/timeentries/year/{year}/all
+    │                       → List<TimeEntryResponse> (all entries for year)
+    │
+    ├── Calendar tab (new tab 4)
+    │       │
+    │       ├── Transform: entries → List<CalendarItem> (one per entry, Start + End + Text)
+    │       │
+    │       ├── Transform: entries → List<Value> (aggregated daily totals per project)
+    │       │       │
+    │       │       └── ValueDefinition per project (Name = project name, color from ProjectColors)
+    │       │           Value.Amount = total seconds for that project on that day
+    │       │
+    │       └── <CalendarView Items="..." Values="..." OnDaySelected="HandleDayClick" />
+    │
+    └── Day click → sets cursor.Date → switches to Day tab showing that day's list
+```
+
+### API consideration
+`GetAllTimeEntriesByYear` already fetches all entries for the year — no new endpoint needed. The calendar is a pure client-side view transform of existing data. This avoids the "over-fetching" concern mentioned in the issue (we're already fetching the year's data for the list view).
+
+---
+
+## Future Extensibility: Multi-User Management Calendar
+
+The same `Heron.MudTotalCalendar` component naturally supports a future management view where multiple users' time appears color-coded on the same grid.
+
+### How it maps to the library's data model
+
+The library's core abstraction is:
+
+```
+ValueDefinition (name, color, format)   ← 1 per "what's being tracked"
+    └── Value (date, definition, amount) ← 1 per day per definition
+```
+
+| Today (Phase 10) | Future management view |
+|-------------------|----------------------|
+| `ValueDefinition` per **project** | `ValueDefinition` per **user** (or per user×project) |
+| `Value.Amount` = total seconds on project that day | `Value.Amount` = total seconds by that user that day |
+| One `CalendarItem` per time entry | One `CalendarItem` per time entry, tagged with user |
+| `CellTemplate` shows project breakdown | `CellTemplate` shows user breakdown with avatar/color |
+
+### Design for extensibility today
+
+**1. Extract the transform logic into its own class** — not inline in the component:
+
+```
+TimeTracker.Client/Features/TimeEntries/Services/CalendarDataTransformer.cs
+├── ToCalendarItems(List<TimeEntryResponse>) → List<CalendarItem>
+├── ToDailyValues(List<TimeEntryResponse>) → List<Value>    // per-project grouping
+└── (future) BuildValues(List<TimeEntryResponse>, GroupingMode) → List<Value>
+```
+
+Today `GroupingMode` is always "by project". The interface stays the same — `CalendarView` just receives `List<Value>` regardless of how they were grouped. In the future, a management page can call `BuildValues(entries, GroupingMode.ByUser)` with a different definition set.
+
+**2. CalendarView component is grouping-agnostic:**
+
+```csharp
+[Parameter] public List<CalendarItem> Items { get; set; } = [];   // event bars
+[Parameter] public List<Value> Totals { get; set; } = [];          // colored daily sums
+[Parameter] public EventCallback<DateTime> OnDaySelected { get; set; }
+```
+
+The component doesn't know or care whether values represent projects, users, or both. It just renders whatever colored value bars it's given.
+
+**3. Future backend API changes (out of scope for #138):**
+
+A management calendar would need:
+- `GET /api/timeentries/admin/month/{month}/year/{year}` — fetches entries for all users (Admin-only)
+- Each `TimeEntryResponse` would need a `UserName` field (or a separate `AdminTimeEntryResponse` DTO)
+- A new `AdminCalendarPage` at `/admin/calendar` (Admin-only, not in bottom nav for regular users)
+
+**4. Visual example of the future state:**
+
+```
+┌──────────────────────────────────────┐
+│  June 2026                           │
+├────┬────┬────┬────┬────┬────┬────┐
+│    │    │    │ 1  │ 2  │ 3  │ 4  │
+│    │    │    │6h15 │4h30 │7h00 │3h20 │
+│    │    │    │━━━━ │━━━━ │━━━━ │━━━━ │
+│    │    │    │🟢AK │🟢AK │🔵ZB │🟢AK │
+│    │    │    │🔵ZB │🔴CM │     │🔴CM │
+├────┼────┼────┼────┼────┼────┼────┤
+│ 5  │ 6  │ 7  │ 8  │ ...              │
+│5h45 │6h00 │8h15 │4h50 │               │
+│━━━━ │━━━━ │━━━━ │━━━━ │               │
+│🟡DJ │🟢AK │🟡DJ │🔵ZB │               │
+│🟢AK │🔵ZB │     │     │               │
+└────┴────┴────┴────┴───────────────────┘
+
+Legend: 🟢 Alice K  🔵 Zak B  🔴 Carlos M  🟡 Dave J
+```
+
+Each colored bar = one user, height/opacity = hours worked. Same `ValueDefinition.Style` mechanism, just different grouping key.
+
+---
+
+## Implementation Plan
+
+### Step 1: Add NuGet packages
+
+**File: `TimeTracker.Client/TimeTracker.Client.csproj`**
+```xml
+<PackageReference Include="Heron.MudCalendar" Version="4.0.0" />
+<PackageReference Include="Heron.MudTotalCalendar" Version="4.0.0" />
+```
+
+### Step 2: Add @using statements
+
+**File: `TimeTracker.Client/_Imports.razor`**
+```razor
+@using Heron.MudCalendar
+@using Heron.MudTotalCalendar
+```
+
+### Step 3: Add CSS/JS references (if needed)
+
+The library auto-injects its references. If display issues occur, add to `TimeTracker.Web/App.razor`:
+```html
+<link href="_content/Heron.MudCalendar/Heron.MudCalendar.min.css" rel="stylesheet" />
+<link href="_content/Heron.MudTotalCalendar/Heron.MudTotalCalendar.min.css" rel="stylesheet" />
+<script type="module" src="_content/Heron.MudCalendar/Heron.MudCalendar.min.js"></script>
+```
+
+### Step 4: Create CalendarDataTransformer service
+
+**New file: `TimeTracker.Client/Features/TimeEntries/Services/CalendarDataTransformer.cs`**
+
+Extracted from the component to keep it grouping-agnostic (see Future Extensibility above). A static/stateless class with two methods:
+
+```csharp
+public static class CalendarDataTransformer
+{
+    // One CalendarItem per time entry (for event bars in the calendar)
+    public static List<CalendarItem> ToCalendarItems(List<TimeEntryResponse> entries) { ... }
+
+    // Daily totals grouped by project → List<Value> for MudTotalCalendar
+    public static List<Value> ToDailyProjectValues(List<TimeEntryResponse> entries) { ... }
+}
+```
+
+`ToDailyProjectValues` groups entries by `Start.Date` then by `Project.Id`, creates one `ValueDefinition` per project (colored via existing `ProjectColors.ForProject()`), and returns `Value` objects with `Amount = totalSeconds` for each day/project combination.
+
+### Step 5: Create CalendarView component
+
+**New file: `TimeTracker.Client/Features/TimeEntries/Components/CalendarView.razor`**
+
+A grouping-agnostic component that receives pre-transformed data:
+
+```csharp
+[Parameter] public List<CalendarItem> Items { get; set; } = [];   // optional event bars
+[Parameter] public List<Value> Totals { get; set; } = [];          // colored daily sums
+[Parameter] public EventCallback<DateTime> OnDaySelected { get; set; }
+[Parameter] public EventCallback<DateTime> OnMonthChanged { get; set; }
+```
+
+The component renders `<MudTotalCalendar>` with project-colored totals per day. It doesn't know or care whether values represent projects, users, or both — just renders whatever it's given.
+
+**Rendering:**
+- If `Items.Count > 0`: show time entry bars on the calendar
+- `Totals`: colored stacked bars per day (one per project, color from `ValueDefinition.Style`)
+- `ShowDayTotal="true"` + `ShowWeekTotal="true"`: built-in totals in the margin
+- `CellTemplate` (optional, for Phase 10): custom day cell showing total hours + project breakdown
+- Day click → `OnDaySelected.InvokeAsync(date)`
+- Month navigation → `OnMonthChanged.InvokeAsync(newMonth)`
+
+### Step 6: Add calendar tab to TimeEntriesPage
+
+**File: `TimeTracker.Client/Features/TimeEntries/Pages/TimeEntriesPage.razor`**
+
+Changes:
+1. Add "Calendar" as 5th tab (index 4)
+2. Store a `selectedCalendarDate` field
+3. When `activeTab == 4`, render `<CalendarView>` instead of the list
+4. `OnDaySelected` handler: set `cursor = date`, switch to `activeTab = 0` (Day tab) to show that day's entries
+5. `OnMonthChanged` handler: update `cursor` to the new month (for year boundary handling when navigating across years — may need to reload data)
+
+```csharp
+// Tab 4: Calendar
+4 => {
+    // calendar fills the area, no additional filtering needed
+}
+```
+
+### Step 7: Handle year boundary navigation
+
+When the user navigates to a different year via the calendar's month stepper, we need to reload entries for that year. The `OnMonthChanged` callback handles this:
+```csharp
+private async Task HandleMonthChanged(DateTime newMonth)
+{
+    if (newMonth.Year != cursor.Year)
+    {
+        cursor = newMonth;
+        await LoadEntries();
+    }
+}
+```
+
+### Step 8: Update mock service (Showcase mode)
+
+**File: `TimeTracker.Client/Mock/MockTimeEntryService.cs`**
+
+Ensure `GetAllTimeEntriesByYear` returns entries spread across multiple months/days so the calendar demonstrates well. Current mock data should already be sufficient (entries scattered across dates).
+
+### Step 9: Tests
+
+**File: `TimeTracker.Tests/Features/TimeEntries/TimeEntryServiceTests.cs`**
+
+No API changes needed, but verify existing tests pass. Optionally add a test verifying `GetAllTimeEntriesByYear` returns entries that can be grouped by day/month for calendar transform (though this is a client-side concern, not a service test).
+
+**File: `TimeTracker.Playwright/Tests/TimeEntriesTests.cs`**
+
+Add a test for the calendar view:
+```csharp
+[Test]
+public async Task CalendarView_ShowsMonthlyGrid_WithDailyTotals()
+{
+    await Page.GotoAsync("/entries");
+    // Click Calendar tab
+    await Page.ClickAsync("button:has-text('Calendar')");
+    // Verify calendar is rendered
+    await Expect(Page.Locator(".mud-calendar")).ToBeVisibleAsync();
+    // Verify day cells show time totals
+    await Expect(Page.Locator(".mud-calendar-cell")).Not.ToHaveCountAsync(0);
+}
+```
+
+If write tests are enabled:
+```csharp
+[Test]
+public async Task CalendarView_ClickDay_ShowsEntriesForThatDay()
+{
+    // ... click calendar tab, click a day with entries, verify Day tab is selected
+    // and entries for that day are shown
+}
+```
+
+---
+
+## Component Tree (calendar tab active)
+
+```
+TimeEntriesPage.razor
+├── Filter tabs (Day | Month | Year | Project | Calendar)
+├── CalendarView.razor                    ← NEW (grouping-agnostic)
+│   └── <MudTotalCalendar T="TimeEntryCalendarItem">
+│       ├── <CellTemplate>                ← custom day cell
+│       │   ├── Total hours for the day
+│       │   └── Project breakdown (colored bars)
+│       └── <TotalTemplate>               ← custom total display
+│           └── Formatted hours
+├── CalendarDataTransformer               ← NEW (extracted transform logic)
+│   ├── ToCalendarItems(entries) → List<CalendarItem>
+│   └── ToDailyProjectValues(entries) → List<Value>
+├── Summary card (when not calendar tab)
+├── Grouped list (when not calendar tab)
+├── FAB (always visible)
+└── EntrySheet (always conditional)
+```
+
+---
+
+## Mobile Considerations
+
+- `Heron.MudTotalCalendar` inherits MudBlazor's responsive grid behavior
+- Day cells shrink on narrow viewports (standard MudBlazor responsive behavior)
+- The calendar is tested in the project's Playwright tests which use `iPhone 14` viewport (`390x844`) — this already validates mobile layout
+- Bottom nav stays fixed; calendar scrolls in the content area above the spacer
+
+---
+
+## Effort Estimate
+
+| Step | Effort |
+|------|--------|
+| 1. Add NuGet packages | 5 min |
+| 2. Add @using statements | 1 min |
+| 3. CSS/JS references (if needed) | 10 min |
+| 4. Create CalendarDataTransformer service | 30 min |
+| 5. Create CalendarView component | 2 hours |
+| 6. Integrate calendar tab into TimeEntriesPage | 1 hour |
+| 7. Year boundary handling | 30 min |
+| 8. Update mock service | 15 min |
+| 9. Tests | 1 hour |
+
+**Total: ~5-6 hours (1 day)**
+
+---
+
+## Validation Checklist
+
+- [ ] Calendar tab appears alongside Day/Month/Year/Project
+- [ ] Monthly grid renders with correct days for the current month
+- [ ] Each day cell shows total hours logged that day
+- [ ] Each day cell shows per-project breakdown with colors
+- [ ] Prev/next month navigation works
+- [ ] Navigating to a different year reloads data correctly
+- [ ] Clicking a day with entries switches to Day tab showing those entries
+- [ ] Clicking a day with no entries shows the empty state
+- [ ] Day with no entries shows "—" or is visually distinct
+- [ ] Mobile viewport (390px) renders correctly
+- [ ] Existing Day/Month/Year/Project tabs still work
+- [ ] FAB and EntrySheet still work from calendar view
+- [ ] Showcase mode works (mock data populates calendar)
+- [ ] `dotnet test` — all green
+- [ ] Playwright tests — new calendar tests pass


### PR DESCRIPTION
Closes #138

## Summary
- Monthly calendar grid with per-project colored value bars
- Hover tooltip shows client name, project name, per-entry time breakdown, and total
- Click value bar → Day tab filtered to that project + date with clearable MudSelect
- Click day cell → Day tab for that date
- CSS fixes: cell overlap, mobile layout, totals column overflow
- 4 new Playwright tests following updated strategy (RunAndWaitForRequestFinishedAsync)
- 2-minute NUnit DefaultTimeout safety net

## Files
- New: CalendarView.razor, CalendarDataTransformer.cs, TimeEntryCalendarItem.cs, ValueTooltipData.cs
- Modified: TimeEntriesPage.razor, app.css, _Imports.razor, TimeTracker.Client.csproj, MockDataStore.cs, playwright.runsettings, TimeEntriesTests.cs, AGENTS.md