### PR TITLE
fix: add MockUserManagementService for showcase mode

### DIFF
--- a/TimeTracker.Client/Mock/MockUserManagementService.cs
+++ b/TimeTracker.Client/Mock/MockUserManagementService.cs
@@ -1,0 +1,28 @@
+using TimeTracker.Contracts.Features.Admin;
+
+namespace TimeTracker.Client.Mock;
+
+public class MockUserManagementService : IUserManagementService
+{
+    private static readonly List<AdminUserResponse> _users =
+    [
+        new("1", "demo@example.com", true)
+    ];
+
+    public Task<List<AdminUserResponse>> GetUsersAsync(CancellationToken ct = default) =>
+        Task.FromResult(_users);
+
+    public Task AddUserAsync(string email, CancellationToken ct = default)
+    {
+        _users.Add(new AdminUserResponse((_users.Count + 1).ToString(), email, false));
+        return Task.CompletedTask;
+    }
+
+    public Task SetAdminRoleAsync(string userId, bool isAdmin, CancellationToken ct = default)
+    {
+        var index = _users.FindIndex(u => u.Id == userId);
+        if (index >= 0)
+            _users[index] = _users[index] with { IsAdmin = isAdmin };
+        return Task.CompletedTask;
+    }
+}

--- a/TimeTracker.Client/Program.cs
+++ b/TimeTracker.Client/Program.cs
@@ -6,6 +6,7 @@ using TimeTracker.Client.Features.Auth;
 using TimeTracker.Client.Features.Clients;
 using TimeTracker.Client.Features.Projects;
 using TimeTracker.Client.Features.TimeEntries;
+using TimeTracker.Contracts.Features.Admin;
 using TimeTracker.Contracts.Features.Clients;
 using TimeTracker.Contracts.Features.Projects;
 using TimeTracker.Contracts.Features.TimeEntries;
@@ -25,6 +26,7 @@ builder.Services.AddSingleton<TimeTracker.Client.Mock.MockDataStore>();
 builder.Services.AddScoped<ITimeEntryService, TimeTracker.Client.Mock.MockTimeEntryService>();
 builder.Services.AddScoped<IProjectService, TimeTracker.Client.Mock.MockProjectService>();
 builder.Services.AddScoped<IClientService, TimeTracker.Client.Mock.MockClientService>();
+builder.Services.AddScoped<IUserManagementService, TimeTracker.Client.Mock.MockUserManagementService>();
 #else
 builder.Services.AddScoped<AuthenticationStateProvider, CookieAuthenticationStateProvider>();
 builder.Services.AddScoped(sp =>


### PR DESCRIPTION
Closes #151

Adds MockUserManagementService with hardcoded demo user (demo@example.com,
Admin). Registers in the SHOWCASE DI block to fix DI resolution crash
when clicking the Users nav item in showcase mode.