### PR TITLE
feat: replace hamburger drawer with nav rail on desktop (#146)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ gh project item-add 1 --owner zkarachiwala --url https://github.com/zkarachiwala
 Run manually after app code changes — do NOT automate via git hooks:
 
 ```bash
-PLAYWRIGHT_WRITE_TESTS=true BROWSER= dotnet test TimeTracker.Playwright --logger "console;verbosity=normal"
+PLAYWRIGHT_WRITE_TESTS=true BROWSER= dotnet test TimeTracker.Playwright --logger "console;verbosity=normal" --blame-hang-timeout 60s
 ```
 
 StopOnError and NumberOfTestWorkers are configured in `TimeTracker.Playwright/playwright.runsettings`, wired into the project via `<RunSettingsFilePath>` in the `.csproj` — no `--settings` flag needed.

--- a/SESSION.md
+++ b/SESSION.md
@@ -1,39 +1,22 @@
 # Session handoff — 2026-06-20
 
 ## Current state
-- Branch: `feature/issue-34-avatar-dropdown` — committed, ready to push and PR
+- Branch: `feature/issue-146-nav-rail` — ready to test and PR
 
 ## Completed this session
-- ✅ Playwright failures fixed — 12 tests were failing because Chromium aborted in-flight `api/timeentries/active` fetch when tests navigated away before `LoadData()` completed; added `"Tracking now" or "Start a timer"` visibility wait to three SetUps (PR #131)
-- ✅ CodeQL alert #8 (CWE-359) resolved — removed `result.Status` enum value from auth log message (PR #132)
-- ✅ **#104 Automated database backup** — nightly `.bacpac` export via GitHub Actions to private `TimeTracker-backups` repo (PRs #133, #134, #135)
-- ✅ **#32 Trash / soft-delete restore** (PR #140)
-- ✅ **D022 documented** — `MigrateAsync()` at startup decision record added to `docs/decisions.md` (PR #141)
-- ✅ **#95 Database-backed user management** (PR #144)
-- ✅ **#34 App bar avatar dropdown** — `MudMenu` replaces static avatar; shows name/email/sign-out on click (PR pending)
-- ✅ **#137 Award rate** — all phases complete on this branch:
-  - D025 added to `docs/decisions.md` — `PublicHoliday` NuGet chosen (Nager.Date rejected: requires paid license key)
-  - TD25 added to `docs/technical-debt.md` — jurisdiction hardcoded to national AU pending external investigation
-  - `Client` entity: `AwardRate (decimal?)` added + EF migration `AddAwardRateToClient`
-  - `ClientResponse`, `ClientRequest`, `ClientCreateRequest`, `ClientUpdateRequest` in Contracts updated
-  - `ClientService` create/update wired through
-  - `ClientSheet.razor` — "Award rate (AUD)" field added
-  - `MockClientService` and `MockDataStore` seed data updated
-  - `IAwardRateResolver` / `AwardRateResolver` using `PublicHoliday.AustraliaPublicHoliday` (national holidays + weekends)
-  - `TimeEntryResponse` — `EffectiveRate (decimal?)` and `IsAwardRate (bool)` added with defaults
-  - `TimeEntryService` — injects resolver, `.ThenInclude(p => p.Client)`, enriches all returned entries
-  - `EntryRow.razor` — "AW" badge shown when `IsAwardRate == true`
-  - 164/164 tests green
+- ✅ **PR #150 merged** — #138 Calendar view
+- ✅ **#146 Navigation rail** — `DrawerVariant.Mini` on desktop/tablet (always-visible 56px icon rail, expands on hover/click); hamburger hidden on desktop via `MudHidden`; drawer footer removed (logout in avatar dropdown); mobile unchanged; `IBrowserViewportService` drives responsive variant switching; Playwright desktop nav tests updated (no more `OpenDrawer()`)
 
 ## Next session
-- Merge PR for #34 once tested
-- **#138** 🟢 Calendar view
+- Run Playwright suite: `PLAYWRIGHT_WRITE_TESTS=true BROWSER= dotnet test TimeTracker.Playwright --logger "console;verbosity=normal"`
+- PR for #146 once Playwright is green
+- Look at fix/issue-151 (showcase users DI) — has uncommitted changes stashed on main (`git stash pop` when switching to that branch)
 
 ## Backlog
 - **#96** 🟢 Staging environment (requires paid tier upgrade)
 - **#102** 🟢 Email/password fallback + TOTP MFA
 - **#121** 🟢 OpenTelemetry → Grafana Cloud APM
-- **#138** 🟢 Calendar view — monthly calendar showing time entries per day
+- **#151** 🔴 Showcase users DI fix
 
 ## Active tech debt (genuine constraints)
 | # | Item | ADR |
@@ -55,4 +38,4 @@ cat SESSION.md
 ```
 
 ---
-*Updated 2026-06-18. Branch `feature/issue-137-award-rate` ready to PR.*
+*Updated 2026-06-20. Branch `feature/issue-146-nav-rail` ready to test.*

--- a/SESSION.md
+++ b/SESSION.md
@@ -1,22 +1,29 @@
-# Session handoff — 2026-06-20
+# Session handoff — 2026-06-21
 
 ## Current state
-- Branch: `feature/issue-146-nav-rail` — ready to test and PR
+- Branch: `feature/issue-146-nav-rail` — PR raised, all 61 Playwright tests green
 
 ## Completed this session
-- ✅ **PR #150 merged** — #138 Calendar view
-- ✅ **#146 Navigation rail** — `DrawerVariant.Mini` on desktop/tablet (always-visible 56px icon rail, expands on hover/click); hamburger hidden on desktop via `MudHidden`; drawer footer removed (logout in avatar dropdown); mobile unchanged; `IBrowserViewportService` drives responsive variant switching; Playwright desktop nav tests updated (no more `OpenDrawer()`)
+- ✅ **#146 Navigation rail** — Playwright suite green; PR raised
+- ✅ **Playwright hang investigation** — root causes identified and fixed:
+  - `GlobalSetup.TearDown`: added `CancelOutputRead/Error` before `Kill(entireProcessTree:true)` to prevent pipe-buffer deadlock
+  - `GlobalSetup.AuthenticateAsync`: explicit disposal scope (request before playwright driver)
+  - `SetDefaultTimeout(30_000)` in both base classes
+  - `PageTearDownAsync` with `WaitAsync(10s)` cap in both base classes
+  - `--blame-hang-timeout 60s` added to run command as process-level safety net
+  - `HangDiagnosticTests` fixture preserved as `[Explicit]` for future teardown testing
+- ✅ **xUnit migration issue raised** — covers Playwright NUnit → xUnit + bUnit component tests
 
 ## Next session
-- Run Playwright suite: `PLAYWRIGHT_WRITE_TESTS=true BROWSER= dotnet test TimeTracker.Playwright --logger "console;verbosity=normal"`
-- PR for #146 once Playwright is green
-- Look at fix/issue-151 (showcase users DI) — has uncommitted changes stashed on main (`git stash pop` when switching to that branch)
+- Merge PR #146 when checks pass
+- Fix/issue-151 (showcase users DI) — stashed changes on main (`git stash pop` when switching)
 
 ## Backlog
 - **#96** 🟢 Staging environment (requires paid tier upgrade)
 - **#102** 🟢 Email/password fallback + TOTP MFA
 - **#121** 🟢 OpenTelemetry → Grafana Cloud APM
 - **#151** 🔴 Showcase users DI fix
+- **xUnit migration** 🟢 Playwright NUnit → Microsoft.Playwright.Xunit + bUnit component tests
 
 ## Active tech debt (genuine constraints)
 | # | Item | ADR |
@@ -38,4 +45,4 @@ cat SESSION.md
 ```
 
 ---
-*Updated 2026-06-20. Branch `feature/issue-146-nav-rail` ready to test.*
+*Updated 2026-06-21. PR for #146 raised.*

--- a/TimeTracker.Client/Shared/Layout/MainLayout.razor
+++ b/TimeTracker.Client/Shared/Layout/MainLayout.razor
@@ -1,6 +1,8 @@
 @inherits LayoutComponentBase
 @inject NavigationManager Nav
-@implements IDisposable
+@inject IBrowserViewportService BrowserViewportService
+@implements IBrowserViewportObserver
+@implements IAsyncDisposable
 
 <MudThemeProvider Theme="@DzkTheme.Instance" />
 <MudPopoverProvider />
@@ -9,9 +11,11 @@
 
 <MudLayout>
     <MudAppBar Elevation="4" Color="Color.Primary" Dense="false">
-        <MudIconButton id="hamburger-btn" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit"
-                       Edge="Edge.Start" aria-label="Open navigation menu"
-                       OnClick="ToggleDrawer" Disabled="@(!RendererInfo.IsInteractive)" />
+        <MudHidden Breakpoint="Breakpoint.MdAndUp">
+            <MudIconButton id="hamburger-btn" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit"
+                           Edge="Edge.Start" aria-label="Open navigation menu"
+                           OnClick="ToggleDrawer" Disabled="@(!RendererInfo.IsInteractive)" />
+        </MudHidden>
         <MudText Typo="Typo.h6" Style="font-weight:500; letter-spacing:.0075em">@PageTitle</MudText>
         <MudSpacer />
         <AuthorizeView>
@@ -51,43 +55,23 @@
         </AuthorizeView>
     </MudAppBar>
 
-    <MudDrawer @bind-Open="drawerOpen" Variant="DrawerVariant.Persistent"
-               Anchor="Anchor.Left" Elevation="16">
+    <MudDrawer @bind-Open="drawerOpen" Variant="@(_isMobile ? DrawerVariant.Persistent : DrawerVariant.Mini)"
+               Anchor="Anchor.Left" Elevation="16"
+               @onmouseenter="OnDrawerMouseEnter" @onmouseleave="OnDrawerMouseLeave">
         <div style="display:flex; flex-direction:column; height:100%">
-            <div style="padding:14px 16px; border-bottom:1px solid var(--mud-palette-divider); display:flex; align-items:center; gap:10px">
+            <div style="padding:14px 8px; border-bottom:1px solid var(--mud-palette-divider); display:flex; align-items:center; gap:8px; overflow:hidden; @(drawerOpen ? "justify-content:flex-start" : "justify-content:center")">
                 <img src="images/clock-logo.png" alt="TimeTracker"
-                     style="width:40px; height:40px; border-radius:8px; object-fit:contain;" />
-                <div style="display:flex; flex-direction:column; line-height:1.15">
-                    <MudText Typo="Typo.subtitle1" Style="font-weight:700; color:var(--mud-palette-secondary); line-height:1.15">TimeTracker</MudText>
-                    <MudText Typo="Typo.caption" Style="line-height:1.15; color:var(--mud-palette-text-secondary)">DZK Consulting</MudText>
-                </div>
+                     style="width:40px; height:40px; border-radius:8px; object-fit:contain; flex-shrink:0;" />
+                @if (drawerOpen)
+                {
+                    <div style="display:flex; flex-direction:column; line-height:1.15; white-space:nowrap">
+                        <MudText Typo="Typo.subtitle1" Style="font-weight:700; color:var(--mud-palette-secondary); line-height:1.15">TimeTracker</MudText>
+                        <MudText Typo="Typo.caption" Style="line-height:1.15; color:var(--mud-palette-text-secondary)">DZK Consulting</MudText>
+                    </div>
+                }
             </div>
             <div style="flex:1; overflow-y:auto">
                 <NavMenu />
-            </div>
-            <div style="border-top:1px solid var(--mud-palette-divider); padding:8px 12px">
-                <AuthorizeView>
-                    <Authorized>
-                        <div style="display:flex; align-items:center; gap:12px; padding:4px 6px">
-                            <MudAvatar Style="background:var(--mud-palette-secondary); color:#fff; font-weight:500; font-size:.9rem; width:36px; height:36px; flex-shrink:0">
-                                @GetInitials(context.User.Identity?.Name)
-                            </MudAvatar>
-                            <div style="flex:1; min-width:0; display:flex; flex-direction:column; gap:1px">
-                                <span style="font-size:.875rem; font-weight:500; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; line-height:1.3">
-                                    @GetDisplayName(context.User.Identity?.Name)
-                                </span>
-                                <span style="font-size:.75rem; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; line-height:1.3; color:var(--mud-palette-text-secondary)">
-                                    @(context.User.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value ?? context.User.Identity?.Name)
-                                </span>
-                            </div>
-                            <form method="post" action="/auth/logout" style="flex-shrink:0">
-                                <AntiforgeryToken />
-                                <MudIconButton ButtonType="ButtonType.Submit" Icon="@Icons.Material.Filled.Logout"
-                                               Color="Color.Default" title="Sign out" Size="Size.Small" />
-                            </form>
-                        </div>
-                    </Authorized>
-                </AuthorizeView>
             </div>
         </div>
     </MudDrawer>
@@ -104,7 +88,22 @@
 
 @code {
     private bool drawerOpen;
+    private bool _isMobile;
+
+    Guid IBrowserViewportObserver.Id { get; } = Guid.NewGuid();
+    MudBlazor.Services.ResizeOptions? IBrowserViewportObserver.ResizeOptions => null;
+
+    async Task IBrowserViewportObserver.NotifyBrowserViewportChangeAsync(BrowserViewportEventArgs args)
+    {
+        _isMobile = args.Breakpoint is Breakpoint.Xs or Breakpoint.Sm;
+        drawerOpen = false;
+        await InvokeAsync(StateHasChanged);
+    }
+
     private void ToggleDrawer() => drawerOpen = !drawerOpen;
+
+    private void OnDrawerMouseEnter() { if (!_isMobile) drawerOpen = true; }
+    private void OnDrawerMouseLeave() { if (!_isMobile) drawerOpen = false; }
 
     private static readonly Dictionary<string, string> TitleMap = new()
     {
@@ -132,14 +131,22 @@
         Nav.LocationChanged += OnLocationChanged;
     }
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+            await BrowserViewportService.SubscribeAsync(this, fireImmediately: true);
+    }
+
     private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
     {
+        drawerOpen = false;
         InvokeAsync(StateHasChanged);
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         Nav.LocationChanged -= OnLocationChanged;
+        await BrowserViewportService.UnsubscribeAsync(this);
     }
 
     private static string GetDisplayName(string? name)

--- a/TimeTracker.Client/Shared/Layout/MainLayout.razor
+++ b/TimeTracker.Client/Shared/Layout/MainLayout.razor
@@ -56,7 +56,7 @@
     </MudAppBar>
 
     <MudDrawer @bind-Open="drawerOpen" Variant="@(_isMobile ? DrawerVariant.Temporary : DrawerVariant.Mini)"
-               Anchor="Anchor.Left" Elevation="16" ClipMode="DrawerClipMode.Always"
+               Anchor="Anchor.Left" Elevation="16"
                @onmouseenter="OnDrawerMouseEnter" @onmouseleave="OnDrawerMouseLeave">
         <div style="display:flex; flex-direction:column; height:100%">
             <div style="padding:14px 8px; border-bottom:1px solid var(--mud-palette-divider); display:flex; align-items:center; gap:8px; overflow:hidden; @(drawerOpen ? "justify-content:flex-start" : "justify-content:center")">

--- a/TimeTracker.Client/Shared/Layout/MainLayout.razor
+++ b/TimeTracker.Client/Shared/Layout/MainLayout.razor
@@ -56,7 +56,7 @@
     </MudAppBar>
 
     <MudDrawer @bind-Open="drawerOpen" Variant="@(_isMobile ? DrawerVariant.Temporary : DrawerVariant.Mini)"
-               Anchor="Anchor.Left" Elevation="16"
+               Anchor="Anchor.Left" Elevation="16" ClipMode="DrawerClipMode.Always"
                @onmouseenter="OnDrawerMouseEnter" @onmouseleave="OnDrawerMouseLeave">
         <div style="display:flex; flex-direction:column; height:100%">
             <div style="padding:14px 8px; border-bottom:1px solid var(--mud-palette-divider); display:flex; align-items:center; gap:8px; overflow:hidden; @(drawerOpen ? "justify-content:flex-start" : "justify-content:center")">

--- a/TimeTracker.Client/Shared/Layout/MainLayout.razor
+++ b/TimeTracker.Client/Shared/Layout/MainLayout.razor
@@ -88,7 +88,7 @@
 
 @code {
     private bool drawerOpen;
-    private bool _isMobile;
+    private bool _isMobile = true;
 
     Guid IBrowserViewportObserver.Id { get; } = Guid.NewGuid();
     MudBlazor.Services.ResizeOptions? IBrowserViewportObserver.ResizeOptions => null;

--- a/TimeTracker.Client/Shared/Layout/MainLayout.razor
+++ b/TimeTracker.Client/Shared/Layout/MainLayout.razor
@@ -1,6 +1,8 @@
 @inherits LayoutComponentBase
 @inject NavigationManager Nav
-@implements IDisposable
+@inject IBrowserViewportService BrowserViewportService
+@implements IBrowserViewportObserver
+@implements IAsyncDisposable
 
 <MudThemeProvider Theme="@DzkTheme.Instance" />
 <MudPopoverProvider />
@@ -53,8 +55,9 @@
         </AuthorizeView>
     </MudAppBar>
 
-    <MudDrawer @bind-Open="drawerOpen" Variant="DrawerVariant.Mini" Breakpoint="Breakpoint.Md"
-               OpenMiniOnHover="true" Anchor="Anchor.Left" Elevation="16">
+    <MudDrawer @bind-Open="drawerOpen" Variant="@(_isMobile ? DrawerVariant.Persistent : DrawerVariant.Mini)"
+               Anchor="Anchor.Left" Elevation="16"
+               @onmouseenter="OnDrawerMouseEnter" @onmouseleave="OnDrawerMouseLeave">
         <div style="display:flex; flex-direction:column; height:100%">
             <div style="padding:14px 8px; border-bottom:1px solid var(--mud-palette-divider); display:flex; align-items:center; gap:8px; overflow:hidden; @(drawerOpen ? "justify-content:flex-start" : "justify-content:center")">
                 <img src="images/clock-logo.png" alt="TimeTracker"
@@ -85,7 +88,22 @@
 
 @code {
     private bool drawerOpen;
+    private bool _isMobile = true;
+
+    Guid IBrowserViewportObserver.Id { get; } = Guid.NewGuid();
+    MudBlazor.Services.ResizeOptions? IBrowserViewportObserver.ResizeOptions => null;
+
+    async Task IBrowserViewportObserver.NotifyBrowserViewportChangeAsync(BrowserViewportEventArgs args)
+    {
+        _isMobile = args.Breakpoint is Breakpoint.Xs or Breakpoint.Sm;
+        drawerOpen = false;
+        await InvokeAsync(StateHasChanged);
+    }
+
     private void ToggleDrawer() => drawerOpen = !drawerOpen;
+
+    private void OnDrawerMouseEnter() { if (!_isMobile) drawerOpen = true; }
+    private void OnDrawerMouseLeave() { if (!_isMobile) drawerOpen = false; }
 
     private static readonly Dictionary<string, string> TitleMap = new()
     {
@@ -113,15 +131,22 @@
         Nav.LocationChanged += OnLocationChanged;
     }
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+            await BrowserViewportService.SubscribeAsync(this, fireImmediately: true);
+    }
+
     private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
     {
         drawerOpen = false;
         InvokeAsync(StateHasChanged);
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         Nav.LocationChanged -= OnLocationChanged;
+        await BrowserViewportService.UnsubscribeAsync(this);
     }
 
     private static string GetDisplayName(string? name)

--- a/TimeTracker.Client/Shared/Layout/MainLayout.razor
+++ b/TimeTracker.Client/Shared/Layout/MainLayout.razor
@@ -1,8 +1,6 @@
 @inherits LayoutComponentBase
 @inject NavigationManager Nav
-@inject IBrowserViewportService BrowserViewportService
-@implements IBrowserViewportObserver
-@implements IAsyncDisposable
+@implements IDisposable
 
 <MudThemeProvider Theme="@DzkTheme.Instance" />
 <MudPopoverProvider />
@@ -55,9 +53,8 @@
         </AuthorizeView>
     </MudAppBar>
 
-    <MudDrawer @bind-Open="drawerOpen" Variant="@(_isMobile ? DrawerVariant.Persistent : DrawerVariant.Mini)"
-               Anchor="Anchor.Left" Elevation="16"
-               @onmouseenter="OnDrawerMouseEnter" @onmouseleave="OnDrawerMouseLeave">
+    <MudDrawer @bind-Open="drawerOpen" Variant="DrawerVariant.Mini" Breakpoint="Breakpoint.Md"
+               OpenMiniOnHover="true" Anchor="Anchor.Left" Elevation="16">
         <div style="display:flex; flex-direction:column; height:100%">
             <div style="padding:14px 8px; border-bottom:1px solid var(--mud-palette-divider); display:flex; align-items:center; gap:8px; overflow:hidden; @(drawerOpen ? "justify-content:flex-start" : "justify-content:center")">
                 <img src="images/clock-logo.png" alt="TimeTracker"
@@ -88,22 +85,7 @@
 
 @code {
     private bool drawerOpen;
-    private bool _isMobile = true;
-
-    Guid IBrowserViewportObserver.Id { get; } = Guid.NewGuid();
-    MudBlazor.Services.ResizeOptions? IBrowserViewportObserver.ResizeOptions => null;
-
-    async Task IBrowserViewportObserver.NotifyBrowserViewportChangeAsync(BrowserViewportEventArgs args)
-    {
-        _isMobile = args.Breakpoint is Breakpoint.Xs or Breakpoint.Sm;
-        drawerOpen = false;
-        await InvokeAsync(StateHasChanged);
-    }
-
     private void ToggleDrawer() => drawerOpen = !drawerOpen;
-
-    private void OnDrawerMouseEnter() { if (!_isMobile) drawerOpen = true; }
-    private void OnDrawerMouseLeave() { if (!_isMobile) drawerOpen = false; }
 
     private static readonly Dictionary<string, string> TitleMap = new()
     {
@@ -131,22 +113,15 @@
         Nav.LocationChanged += OnLocationChanged;
     }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender)
-            await BrowserViewportService.SubscribeAsync(this, fireImmediately: true);
-    }
-
     private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
     {
         drawerOpen = false;
         InvokeAsync(StateHasChanged);
     }
 
-    public async ValueTask DisposeAsync()
+    public void Dispose()
     {
         Nav.LocationChanged -= OnLocationChanged;
-        await BrowserViewportService.UnsubscribeAsync(this);
     }
 
     private static string GetDisplayName(string? name)

--- a/TimeTracker.Client/Shared/Layout/MainLayout.razor
+++ b/TimeTracker.Client/Shared/Layout/MainLayout.razor
@@ -55,7 +55,7 @@
         </AuthorizeView>
     </MudAppBar>
 
-    <MudDrawer @bind-Open="drawerOpen" Variant="@(_isMobile ? DrawerVariant.Persistent : DrawerVariant.Mini)"
+    <MudDrawer @bind-Open="drawerOpen" Variant="@(_isMobile ? DrawerVariant.Temporary : DrawerVariant.Mini)"
                Anchor="Anchor.Left" Elevation="16"
                @onmouseenter="OnDrawerMouseEnter" @onmouseleave="OnDrawerMouseLeave">
         <div style="display:flex; flex-direction:column; height:100%">

--- a/TimeTracker.Client/Shared/Theme/DzkTheme.cs
+++ b/TimeTracker.Client/Shared/Theme/DzkTheme.cs
@@ -38,6 +38,7 @@ public static class DzkTheme
         {
             DefaultBorderRadius = "6px",
             DrawerWidthLeft = "256px",
+            DrawerMiniWidthLeft = "56px",
         }
     };
 }

--- a/TimeTracker.Playwright/AuthenticatedDesktopPageTest.cs
+++ b/TimeTracker.Playwright/AuthenticatedDesktopPageTest.cs
@@ -38,5 +38,14 @@ public class AuthenticatedDesktopPageTest : PageTest
             $"Unexpected browser console errors:\n{string.Join("\n", _consoleErrors)}");
     }
 
-
+    [TearDown]
+    public async Task PageTearDownAsync()
+    {
+        try
+        {
+            if (Page is not null)
+                await Page.CloseAsync().WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+        }
+        catch { }
+    }
 }

--- a/TimeTracker.Playwright/AuthenticatedDesktopPageTest.cs
+++ b/TimeTracker.Playwright/AuthenticatedDesktopPageTest.cs
@@ -18,7 +18,7 @@ public class AuthenticatedDesktopPageTest : PageTest
     [SetUp]
     public void MonitorConsoleErrors()
     {
-        Page.SetDefaultTimeout(120_000);
+        Page.SetDefaultTimeout(30_000);
         _consoleErrors.Clear();
         _onConsoleMessage = (_, msg) =>
         {
@@ -44,7 +44,7 @@ public class AuthenticatedDesktopPageTest : PageTest
         try
         {
             if (Page is not null)
-                await Page.CloseAsync().ConfigureAwait(false);
+                await Page.CloseAsync().WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
         }
         catch { }
     }

--- a/TimeTracker.Playwright/AuthenticatedDesktopPageTest.cs
+++ b/TimeTracker.Playwright/AuthenticatedDesktopPageTest.cs
@@ -18,7 +18,7 @@ public class AuthenticatedDesktopPageTest : PageTest
     [SetUp]
     public void MonitorConsoleErrors()
     {
-        Page.SetDefaultTimeout(30_000);
+        Page.SetDefaultTimeout(120_000);
         _consoleErrors.Clear();
         _onConsoleMessage = (_, msg) =>
         {
@@ -36,5 +36,16 @@ public class AuthenticatedDesktopPageTest : PageTest
         if (_onConsoleMessage is not null) Page.Console -= _onConsoleMessage;
         Assert.That(_consoleErrors, Is.Empty,
             $"Unexpected browser console errors:\n{string.Join("\n", _consoleErrors)}");
+    }
+
+    [TearDown]
+    public async Task PageTearDownAsync()
+    {
+        try
+        {
+            if (Page is not null)
+                await Page.CloseAsync().ConfigureAwait(false);
+        }
+        catch { }
     }
 }

--- a/TimeTracker.Playwright/AuthenticatedDesktopPageTest.cs
+++ b/TimeTracker.Playwright/AuthenticatedDesktopPageTest.cs
@@ -18,6 +18,7 @@ public class AuthenticatedDesktopPageTest : PageTest
     [SetUp]
     public void MonitorConsoleErrors()
     {
+        Page.SetDefaultTimeout(30_000);
         _consoleErrors.Clear();
         _onConsoleMessage = (_, msg) =>
         {

--- a/TimeTracker.Playwright/AuthenticatedDesktopPageTest.cs
+++ b/TimeTracker.Playwright/AuthenticatedDesktopPageTest.cs
@@ -38,14 +38,5 @@ public class AuthenticatedDesktopPageTest : PageTest
             $"Unexpected browser console errors:\n{string.Join("\n", _consoleErrors)}");
     }
 
-    [TearDown]
-    public async Task PageTearDownAsync()
-    {
-        try
-        {
-            if (Page is not null)
-                await Page.CloseAsync().WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
-        }
-        catch { }
-    }
+
 }

--- a/TimeTracker.Playwright/AuthenticatedPageTest.cs
+++ b/TimeTracker.Playwright/AuthenticatedPageTest.cs
@@ -38,5 +38,14 @@ public class AuthenticatedPageTest : PageTest
             $"Unexpected browser console errors:\n{string.Join("\n", _consoleErrors)}");
     }
 
-
+    [TearDown]
+    public async Task PageTearDownAsync()
+    {
+        try
+        {
+            if (Page is not null)
+                await Page.CloseAsync().WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+        }
+        catch { }
+    }
 }

--- a/TimeTracker.Playwright/AuthenticatedPageTest.cs
+++ b/TimeTracker.Playwright/AuthenticatedPageTest.cs
@@ -18,7 +18,7 @@ public class AuthenticatedPageTest : PageTest
     [SetUp]
     public void MonitorConsoleErrors()
     {
-        Page.SetDefaultTimeout(30_000);
+        Page.SetDefaultTimeout(120_000);
         _consoleErrors.Clear();
         _onConsoleMessage = (_, msg) =>
         {
@@ -36,5 +36,16 @@ public class AuthenticatedPageTest : PageTest
         if (_onConsoleMessage is not null) Page.Console -= _onConsoleMessage;
         Assert.That(_consoleErrors, Is.Empty,
             $"Unexpected browser console errors:\n{string.Join("\n", _consoleErrors)}");
+    }
+
+    [TearDown]
+    public async Task PageTearDownAsync()
+    {
+        try
+        {
+            if (Page is not null)
+                await Page.CloseAsync().ConfigureAwait(false);
+        }
+        catch { }
     }
 }

--- a/TimeTracker.Playwright/AuthenticatedPageTest.cs
+++ b/TimeTracker.Playwright/AuthenticatedPageTest.cs
@@ -38,14 +38,5 @@ public class AuthenticatedPageTest : PageTest
             $"Unexpected browser console errors:\n{string.Join("\n", _consoleErrors)}");
     }
 
-    [TearDown]
-    public async Task PageTearDownAsync()
-    {
-        try
-        {
-            if (Page is not null)
-                await Page.CloseAsync().WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
-        }
-        catch { }
-    }
+
 }

--- a/TimeTracker.Playwright/AuthenticatedPageTest.cs
+++ b/TimeTracker.Playwright/AuthenticatedPageTest.cs
@@ -18,6 +18,7 @@ public class AuthenticatedPageTest : PageTest
     [SetUp]
     public void MonitorConsoleErrors()
     {
+        Page.SetDefaultTimeout(30_000);
         _consoleErrors.Clear();
         _onConsoleMessage = (_, msg) =>
         {

--- a/TimeTracker.Playwright/AuthenticatedPageTest.cs
+++ b/TimeTracker.Playwright/AuthenticatedPageTest.cs
@@ -18,7 +18,7 @@ public class AuthenticatedPageTest : PageTest
     [SetUp]
     public void MonitorConsoleErrors()
     {
-        Page.SetDefaultTimeout(120_000);
+        Page.SetDefaultTimeout(30_000);
         _consoleErrors.Clear();
         _onConsoleMessage = (_, msg) =>
         {
@@ -44,7 +44,7 @@ public class AuthenticatedPageTest : PageTest
         try
         {
             if (Page is not null)
-                await Page.CloseAsync().ConfigureAwait(false);
+                await Page.CloseAsync().WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
         }
         catch { }
     }

--- a/TimeTracker.Playwright/GlobalSetup.cs
+++ b/TimeTracker.Playwright/GlobalSetup.cs
@@ -25,15 +25,25 @@ public class GlobalSetup
     [OneTimeTearDown]
     public void TearDown()
     {
+        if (_appProcess == null || _appProcess.HasExited)
+        {
+            _appProcess?.Dispose();
+            return;
+        }
         try
         {
-            _appProcess?.Kill(entireProcessTree: true);
-            _appProcess?.WaitForExit(5000);
+            // Cancel async reads before kill — prevents the pipe-buffer deadlock where
+            // Kill(entireProcessTree:true) freezes waiting for I/O handles that never
+            // receive EOF because a zombie child has them open.
+            _appProcess.CancelOutputRead();
+            _appProcess.CancelErrorRead();
+            _appProcess.Kill(entireProcessTree: true);
+            _appProcess.WaitForExit(3000);
         }
         catch { }
         finally
         {
-            _appProcess?.Dispose();
+            _appProcess.Dispose();
         }
     }
 
@@ -66,19 +76,23 @@ public class GlobalSetup
     private static async Task AuthenticateAsync()
     {
         using var playwright = await Microsoft.Playwright.Playwright.CreateAsync();
-        await using var request = await playwright.APIRequest.NewContextAsync(new()
         {
-            BaseURL = TestBaseUrl,
-            IgnoreHTTPSErrors = true,
-        });
+            // Inner scope ensures request.DisposeAsync() is called before playwright.Dispose(),
+            // guaranteeing the Node.js driver does not outlive its API context.
+            await using var request = await playwright.APIRequest.NewContextAsync(new()
+            {
+                BaseURL = TestBaseUrl,
+                IgnoreHTTPSErrors = true,
+            });
 
-        var response = await request.GetAsync("/api/dev/login");
-        if (!response.Ok)
-            throw new Exception(
-                $"Dev login failed ({response.Status}). App must run with ASPNETCORE_ENVIRONMENT=Development.");
+            var response = await request.GetAsync("/api/dev/login");
+            if (!response.Ok)
+                throw new Exception(
+                    $"Dev login failed ({response.Status}). App must run with ASPNETCORE_ENVIRONMENT=Development.");
 
-        Directory.CreateDirectory(Path.GetDirectoryName(TestConfig.AuthStatePath)!);
-        await request.StorageStateAsync(new() { Path = TestConfig.AuthStatePath });
+            Directory.CreateDirectory(Path.GetDirectoryName(TestConfig.AuthStatePath)!);
+            await request.StorageStateAsync(new() { Path = TestConfig.AuthStatePath });
+        }
     }
 
     private static async Task WaitForAppAsync(int timeoutSeconds)

--- a/TimeTracker.Playwright/Tests/DesktopAdminTests.cs
+++ b/TimeTracker.Playwright/Tests/DesktopAdminTests.cs
@@ -28,6 +28,34 @@ public class DesktopTimerTests : AuthenticatedDesktopPageTest
     }
 }
 
+/// <summary>
+/// Explicit hang-diagnostic fixture — NOT part of the normal test run.
+/// Run manually to verify teardown hang behaviour after a deliberate Playwright timeout.
+/// Target with: dotnet test --filter FullyQualifiedName~HangDiagnosticTests
+/// </summary>
+[TestFixture]
+[Explicit("Hang diagnostic only — clicks a non-existent element to force a timeout and observe teardown behaviour")]
+public class HangDiagnosticTests : AuthenticatedDesktopPageTest
+{
+    [SetUp]
+    public async Task NavigateToTimer()
+    {
+        await Page.RunAndWaitForRequestFinishedAsync(
+            async () => await Page.GotoAsync("/"),
+            new() { Predicate = r => r.Url.Contains("/api/timeentries/today"), Timeout = 15_000 }
+        );
+        await Expect(Page.Locator(".tt-fab button")).ToBeEnabledAsync(new() { Timeout = 30_000 });
+        // Intentionally clicks a button that does not exist on desktop (nav rail replaced the hamburger).
+        // This forces a 30s Playwright timeout to exercise teardown hang behaviour.
+        await Page.Locator("#hamburger-btn").ClickAsync();
+    }
+
+    [Test]
+    public async Task HangDiagnostic_WillAlwaysFail() =>
+        await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "Timer" }).First)
+            .ToBeInViewportAsync(new() { Timeout = 5_000 });
+}
+
 [TestFixture]
 public class DesktopAdminNavTests : AuthenticatedDesktopPageTest
 {
@@ -39,10 +67,9 @@ public class DesktopAdminNavTests : AuthenticatedDesktopPageTest
             new() { Predicate = r => r.Url.Contains("/api/timeentries/today"), Timeout = 15_000 }
         );
         await Expect(Page.Locator(".tt-fab button")).ToBeEnabledAsync(new() { Timeout = 30_000 });
-        // Open hamburger drawer to reveal nav links
-        await Page.Locator("#hamburger-btn").ClickAsync();
-        await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "Timer" }).First)
-            .ToBeInViewportAsync(new() { Timeout = 5_000 });
+        // On desktop the nav rail is always visible — no drawer to open
+        await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "Users" }))
+            .ToBeAttachedAsync(new() { Timeout = 10_000 });
     }
 
     [Test]

--- a/TimeTracker.Playwright/Tests/DesktopAdminTests.cs
+++ b/TimeTracker.Playwright/Tests/DesktopAdminTests.cs
@@ -39,10 +39,9 @@ public class DesktopAdminNavTests : AuthenticatedDesktopPageTest
             new() { Predicate = r => r.Url.Contains("/api/timeentries/today"), Timeout = 15_000 }
         );
         await Expect(Page.Locator(".tt-fab button")).ToBeEnabledAsync(new() { Timeout = 30_000 });
-        // Open hamburger drawer to reveal nav links
-        await Page.Locator("#hamburger-btn").ClickAsync();
-        await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "Timer" }).First)
-            .ToBeInViewportAsync(new() { Timeout = 5_000 });
+        // On desktop the nav rail is always visible — no drawer to open
+        await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "Users" }))
+            .ToBeAttachedAsync(new() { Timeout = 10_000 });
     }
 
     [Test]

--- a/TimeTracker.Playwright/Tests/DesktopAdminTests.cs
+++ b/TimeTracker.Playwright/Tests/DesktopAdminTests.cs
@@ -39,9 +39,10 @@ public class DesktopAdminNavTests : AuthenticatedDesktopPageTest
             new() { Predicate = r => r.Url.Contains("/api/timeentries/today"), Timeout = 15_000 }
         );
         await Expect(Page.Locator(".tt-fab button")).ToBeEnabledAsync(new() { Timeout = 30_000 });
-        // On desktop the nav rail is always visible — no drawer to open
-        await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "Users" }))
-            .ToBeAttachedAsync(new() { Timeout = 10_000 });
+        // Open hamburger drawer to reveal nav links
+        await Page.Locator("#hamburger-btn").ClickAsync();
+        await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "Timer" }).First)
+            .ToBeInViewportAsync(new() { Timeout = 5_000 });
     }
 
     [Test]

--- a/TimeTracker.Playwright/Tests/DesktopNavigationTests.cs
+++ b/TimeTracker.Playwright/Tests/DesktopNavigationTests.cs
@@ -13,52 +13,33 @@ public class DesktopNavigationTests : AuthenticatedDesktopPageTest
         await Expect(Page.Locator(".tt-fab button")).ToBeEnabledAsync(new() { Timeout = 30_000 });
     }
 
-    private async Task OpenDrawer()
-    {
-        await Page.Locator("#hamburger-btn").ClickAsync();
-        await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "Timer" }).First)
-            .ToBeInViewportAsync(new() { Timeout = 5_000 });
-    }
-
     [Test]
-    public async Task DrawerOpensOnHamburgerClick()
+    public async Task RailNavEntriesNavigatesToEntries()
     {
-        await Page.Locator("#hamburger-btn").ClickAsync();
-        await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "Timer" }).First)
-            .ToBeInViewportAsync(new() { Timeout = 5_000 });
-    }
-
-    [Test]
-    public async Task DrawerNavEntriesNavigatesToEntries()
-    {
-        await OpenDrawer();
         await Page.GetByRole(AriaRole.Link, new() { Name = "Entries" }).ClickAsync();
         await Expect(Page).ToHaveURLAsync(new Regex("/entries"));
         await Expect(Page.GetByText("Total tracked")).ToBeVisibleAsync(new() { Timeout = 15_000 });
     }
 
     [Test]
-    public async Task DrawerNavReportsNavigatesToReports()
+    public async Task RailNavReportsNavigatesToReports()
     {
-        await OpenDrawer();
         await Page.GetByRole(AriaRole.Link, new() { Name = "Reports" }).ClickAsync();
         await Expect(Page).ToHaveURLAsync(new Regex("/reports"));
         await Expect(Page.GetByText("YTD hours")).ToBeVisibleAsync(new() { Timeout = 15_000 });
     }
 
     [Test]
-    public async Task DrawerNavProjectsNavigatesToProjects()
+    public async Task RailNavProjectsNavigatesToProjects()
     {
-        await OpenDrawer();
         await Page.GetByRole(AriaRole.Link, new() { Name = "Projects" }).ClickAsync();
         await Expect(Page).ToHaveURLAsync(new Regex("/projects"));
         await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Projects" }).First).ToBeVisibleAsync(new() { Timeout = 15_000 });
     }
 
     [Test]
-    public async Task DrawerNavClientsNavigatesToClients()
+    public async Task RailNavClientsNavigatesToClients()
     {
-        await OpenDrawer();
         await Page.GetByRole(AriaRole.Link, new() { Name = "Clients" }).ClickAsync();
         await Expect(Page).ToHaveURLAsync(new Regex("/clients"));
         await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Clients" }).First).ToBeVisibleAsync(new() { Timeout = 15_000 });
@@ -73,14 +54,12 @@ public class DesktopNavigationTests : AuthenticatedDesktopPageTest
     }
 
     [Test]
-    public async Task DrawerNavTimerNavigatesBackToTimer()
+    public async Task RailNavTimerNavigatesBackToTimer()
     {
-        await OpenDrawer();
         await Page.GetByRole(AriaRole.Link, new() { Name = "Entries" }).ClickAsync();
         await Expect(Page).ToHaveURLAsync(new Regex("/entries"));
         await Expect(Page.GetByText("Total tracked")).ToBeVisibleAsync(new() { Timeout = 15_000 });
 
-        // Drawer stays open after client-side navigation in WASM (MainLayout state persists).
         await Page.GetByRole(AriaRole.Link, new() { Name = "Timer" }).First.ClickAsync();
         await Expect(Page).ToHaveURLAsync(new Regex("/$|/\\?"));
         await Expect(Page.GetByText("Tracking now").Or(Page.GetByText("Start a timer")))

--- a/TimeTracker.Web/Shared/Layout/MainLayout.razor
+++ b/TimeTracker.Web/Shared/Layout/MainLayout.razor
@@ -21,8 +21,8 @@
         </AuthorizeView>
     </MudAppBar>
 
-    <MudDrawer Open="false" Variant="DrawerVariant.Mini" Breakpoint="Breakpoint.Md"
-               OpenMiniOnHover="true" Anchor="Anchor.Left" Elevation="16">
+    <MudDrawer Open="false" Variant="DrawerVariant.Mini"
+               Anchor="Anchor.Left" Elevation="16">
         <div style="display:flex; flex-direction:column; height:100%">
             <div style="padding:14px 8px; border-bottom:1px solid var(--mud-palette-divider); display:flex; align-items:center; justify-content:center">
                 <img src="/images/clock-logo.png" alt="TimeTracker"

--- a/TimeTracker.Web/Shared/Layout/MainLayout.razor
+++ b/TimeTracker.Web/Shared/Layout/MainLayout.razor
@@ -10,9 +10,6 @@
 
 <MudLayout>
     <MudAppBar Elevation="4" Color="Color.Primary" Dense="false">
-        <MudIconButton id="hamburger-btn" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit"
-                       Edge="Edge.Start" aria-label="Open navigation menu"
-                       OnClick="ToggleDrawer" />
         <MudText Typo="Typo.h6" Style="font-weight:500; letter-spacing:.0075em">@PageTitle</MudText>
         <MudSpacer />
         <AuthorizeView>
@@ -24,43 +21,15 @@
         </AuthorizeView>
     </MudAppBar>
 
-    <MudDrawer @bind-Open="drawerOpen" Variant="DrawerVariant.Persistent"
+    <MudDrawer Open="false" Variant="DrawerVariant.Mini"
                Anchor="Anchor.Left" Elevation="16">
         <div style="display:flex; flex-direction:column; height:100%">
-            <div style="padding:14px 16px; border-bottom:1px solid var(--mud-palette-divider); display:flex; align-items:center; gap:10px">
+            <div style="padding:14px 8px; border-bottom:1px solid var(--mud-palette-divider); display:flex; align-items:center; justify-content:center">
                 <img src="/images/clock-logo.png" alt="TimeTracker"
                      style="width:40px; height:40px; border-radius:8px; object-fit:contain;" />
-                <div style="display:flex; flex-direction:column; line-height:1.15">
-                    <MudText Typo="Typo.subtitle1" Style="font-weight:700; color:var(--mud-palette-secondary); line-height:1.15">TimeTracker</MudText>
-                    <MudText Typo="Typo.caption" Style="line-height:1.15; color:var(--mud-palette-text-secondary)">DZK Consulting</MudText>
-                </div>
             </div>
             <div style="flex:1; overflow-y:auto">
-                <NavMenu OnNavClick="() => drawerOpen = false" />
-            </div>
-            <div style="border-top:1px solid var(--mud-palette-divider); padding:8px 12px">
-                <AuthorizeView>
-                    <Authorized>
-                        <div style="display:flex; align-items:center; gap:12px; padding:4px 6px">
-                            <MudAvatar Style="background:var(--mud-palette-secondary); color:#fff; font-weight:500; font-size:.9rem; width:36px; height:36px; flex-shrink:0">
-                                @GetInitials(context.User.Identity?.Name)
-                            </MudAvatar>
-                            <div style="flex:1; min-width:0; display:flex; flex-direction:column; gap:1px">
-                                <span style="font-size:.875rem; font-weight:500; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; line-height:1.3">
-                                    @GetDisplayName(context.User.Identity?.Name)
-                                </span>
-                                <span style="font-size:.75rem; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; line-height:1.3; color:var(--mud-palette-text-secondary)">
-                                    @(context.User.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value ?? context.User.Identity?.Name)
-                                </span>
-                            </div>
-                            <form method="post" action="/auth/logout" style="flex-shrink:0">
-                                <AntiforgeryToken />
-                                <MudIconButton ButtonType="ButtonType.Submit" Icon="@Icons.Material.Filled.Logout"
-                                               Color="Color.Default" title="Sign out" Size="Size.Small" />
-                            </form>
-                        </div>
-                    </Authorized>
-                </AuthorizeView>
+                <NavMenu />
             </div>
         </div>
     </MudDrawer>
@@ -76,9 +45,6 @@
 <BottomNav />
 
 @code {
-    private bool drawerOpen;
-    private void ToggleDrawer() => drawerOpen = !drawerOpen;
-
     private static readonly Dictionary<string, string> TitleMap = new()
     {
         { "",         "TimeTracker" },

--- a/TimeTracker.Web/Shared/Layout/MainLayout.razor
+++ b/TimeTracker.Web/Shared/Layout/MainLayout.razor
@@ -21,8 +21,8 @@
         </AuthorizeView>
     </MudAppBar>
 
-    <MudDrawer Open="false" Variant="DrawerVariant.Mini"
-               Anchor="Anchor.Left" Elevation="16">
+    <MudDrawer Open="false" Variant="DrawerVariant.Mini" Breakpoint="Breakpoint.Md"
+               OpenMiniOnHover="true" Anchor="Anchor.Left" Elevation="16">
         <div style="display:flex; flex-direction:column; height:100%">
             <div style="padding:14px 8px; border-bottom:1px solid var(--mud-palette-divider); display:flex; align-items:center; justify-content:center">
                 <img src="/images/clock-logo.png" alt="TimeTracker"

--- a/TimeTracker.Web/Shared/Theme/DzkTheme.cs
+++ b/TimeTracker.Web/Shared/Theme/DzkTheme.cs
@@ -38,6 +38,7 @@ public static class DzkTheme
         {
             DefaultBorderRadius = "6px",
             DrawerWidthLeft = "256px",
+            DrawerMiniWidthLeft = "56px",
         }
     };
 }

--- a/TimeTracker.Web/wwwroot/css/app.css
+++ b/TimeTracker.Web/wwwroot/css/app.css
@@ -197,6 +197,21 @@ html, body, #app {
     color: var(--mud-palette-primary) !important;
 }
 
+/* ── Nav rail — centre icons in mini drawer ── */
+.mud-drawer--mini .mud-nav-link {
+    margin: 2px 4px !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    justify-content: center !important;
+}
+
+/* ── Nav rail — hide mini drawer on mobile until JS switches to Persistent ── */
+@media (max-width: 959px) {
+    .mud-drawer--mini {
+        display: none !important;
+    }
+}
+
 /* ── Entry sheet — bottom sheet ── */
 .entry-sheet .mud-drawer-content {
     max-height: 92vh;

--- a/TimeTracker.Web/wwwroot/css/app.css
+++ b/TimeTracker.Web/wwwroot/css/app.css
@@ -197,7 +197,13 @@ html, body, #app {
     color: var(--mud-palette-primary) !important;
 }
 
-/* ── Nav rail — centre icons when drawer is in mini/closed state ── */
+/* ── Nav rail — hide text and centre icons in mini/closed state ── */
+/* MudBlazor's built-in selector requires NavMenu as direct child of .mud-drawer-content,
+   which our wrapper div breaks — so we apply a permissive override instead */
+.mud-drawer--closed.mud-drawer-mini .mud-nav-link-text {
+    display: none !important;
+}
+
 .mud-drawer--closed.mud-drawer-mini .mud-nav-link {
     padding-left: 0 !important;
     padding-right: 0 !important;

--- a/TimeTracker.Web/wwwroot/css/app.css
+++ b/TimeTracker.Web/wwwroot/css/app.css
@@ -197,21 +197,6 @@ html, body, #app {
     color: var(--mud-palette-primary) !important;
 }
 
-/* ── Nav rail — centre icons in mini drawer ── */
-.mud-drawer--mini .mud-nav-link {
-    margin: 2px 4px !important;
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-    justify-content: center !important;
-}
-
-/* ── Nav rail — hide mini drawer on mobile until JS switches to Persistent ── */
-@media (max-width: 959px) {
-    .mud-drawer--mini {
-        display: none !important;
-    }
-}
-
 /* ── Entry sheet — bottom sheet ── */
 .entry-sheet .mud-drawer-content {
     max-height: 92vh;

--- a/TimeTracker.Web/wwwroot/css/app.css
+++ b/TimeTracker.Web/wwwroot/css/app.css
@@ -197,6 +197,20 @@ html, body, #app {
     color: var(--mud-palette-primary) !important;
 }
 
+/* ── Nav rail — centre icons when drawer is in mini/closed state ── */
+.mud-drawer--closed.mud-drawer-mini .mud-nav-link {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    justify-content: center !important;
+}
+
+/* ── Nav rail — hide mini drawer on mobile to prevent flash before JS sets Persistent variant ── */
+@media (max-width: 959px) {
+    .mud-drawer-mini {
+        display: none !important;
+    }
+}
+
 /* ── Entry sheet — bottom sheet ── */
 .entry-sheet .mud-drawer-content {
     max-height: 92vh;

--- a/TimeTracker.Web/wwwroot/css/app.css
+++ b/TimeTracker.Web/wwwroot/css/app.css
@@ -201,7 +201,15 @@ html, body, #app {
 /* MudBlazor's built-in selector requires NavMenu as direct child of .mud-drawer-content,
    which our wrapper div breaks — so we apply a permissive override instead */
 .mud-drawer--closed.mud-drawer-mini .mud-nav-link-text {
-    display: none !important;
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
 }
 
 .mud-drawer--closed.mud-drawer-mini .mud-nav-link {

--- a/docs/playwright-strategy.md
+++ b/docs/playwright-strategy.md
@@ -1,6 +1,6 @@
 # Playwright Test Strategy
 
-Sources consulted: [Playwright Best Practices](https://playwright.dev/docs/best-practices), [Playwright .NET Writing Tests](https://playwright.dev/dotnet/docs/writing-tests), [Playwright Network - waitForResponse](https://playwright.dev/docs/network), [BrowserStack waitForResponse guide](https://www.browserstack.com/guide/playwright-waitforresponse), [Checkly waits and timeouts](https://www.checklyhq.com/docs/learn/playwright/waits-and-timeouts/)
+Sources consulted: [Playwright Best Practices](https://playwright.dev/docs/best-practices), [Playwright .NET Writing Tests](https://playwright.dev/dotnet/docs/writing-tests), [Playwright Network - waitForResponse](https://playwright.dev/docs/network), [BrowserStack waitForResponse guide](https://www.browserstack.com/guide/playwright-waitforresponse), [Checkly waits and timeouts](https://www.checklyhq.com/docs/learn/playwright/waits-and-timeouts/), [playwright-dotnet issue #2530](https://github.com/microsoft/playwright-dotnet/issues/2530), [playwright-dotnet BrowserTest source](https://github.com/microsoft/playwright-dotnet/blob/main/src/Playwright.NUnit/BrowserTest.cs)
 
 ---
 
@@ -37,6 +37,8 @@ Production auth is Google OAuth — there is no username/password. Playwright ca
 Both base classes pass `StorageStatePath = TestConfig.AuthStatePath` in `ContextOptions()`. Playwright loads `user.json` and injects its cookies into every new browser context — each test starts already authenticated, no login flow required per test.
 
 `TestConfig.AuthStatePath` resolves to `<build-output>/playwright/.auth/user.json`. This file is generated fresh on each test run (GlobalSetup always recreates it) and is not committed to source control.
+
+Both base classes also set `Page.SetDefaultTimeout(30_000)` in `[SetUp]` and include a `PageTearDownAsync` — see the teardown hang section below.
 
 ### The dev login endpoint (`/api/dev/login`)
 
@@ -267,6 +269,80 @@ These are distinct:
 - **Browser console `"Request failed: <url>"`** — written by Blazor when `HttpRequestException` goes unhandled. This IS caught by `AssertNoConsoleErrors`.
 
 `AuthenticatedPageTest` monitors console errors only. `Page.RequestFailed` is not tracked — teardown aborts that cause Blazor console errors are fixed in the app's catch blocks, not by filtering the console monitor.
+
+---
+
+## Teardown hang — root cause and fix
+
+### Why Playwright hangs indefinitely after a test failure
+
+Playwright NUnit's `BrowserTest.BrowserTearDown()` contains this conditional:
+
+```csharp
+[TearDown]
+public async Task BrowserTearDown()
+{
+    if (TestOk())  // only closes context when test PASSED or was SKIPPED
+    {
+        foreach (var context in _contexts)
+            await context.CloseAsync().ConfigureAwait(false);
+    }
+    _contexts.Clear();
+}
+```
+
+`TestOk()` returns `false` on any failure. When it does, the browser context is **never closed** — it is only removed from the tracking list. Any pending network operations (in-flight API calls, navigations) remain running. The process cannot exit cleanly, causing an indefinite hang that requires Ctrl+C.
+
+This is by design in Playwright (preserves state for failure screenshots/traces) but is the wrong default for a test suite where you just want clean exit on failure.
+
+### The fix — explicit PageTearDownAsync in base classes
+
+Both `AuthenticatedPageTest` and `AuthenticatedDesktopPageTest` include:
+
+```csharp
+[TearDown]
+public async Task PageTearDownAsync()
+{
+    try
+    {
+        if (Page is not null)
+            await Page.CloseAsync().WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+    }
+    catch { }
+}
+```
+
+Key points:
+- `Page.CloseAsync()` has no built-in timeout parameter — `WaitAsync(TimeSpan)` is the correct way to add one
+- The 10-second cap ensures teardown never hangs indefinitely even if `CloseAsync` itself stalls
+- The bare `catch { }` is intentional — the page may already be closing or in an unknown state; swallow everything
+- NUnit runs **all** `[TearDown]` methods in the hierarchy even if one throws, so `AssertNoConsoleErrors` and `PageTearDownAsync` both always run
+- `Page.SetDefaultTimeout(30_000)` is set in `[SetUp]` to ensure all Playwright operations timeout within 30s rather than relying on Playwright's internal default
+
+### DefaultTimeout in playwright.runsettings
+
+`<DefaultTimeout>120000</DefaultTimeout>` in `playwright.runsettings` is NUnit's **per-test wall-clock limit** — it is NOT Playwright's action/assertion timeout. These are completely separate systems. Playwright's timeout is controlled by `Page.SetDefaultTimeout()`. Do not confuse the two.
+
+---
+
+## Nav rail — desktop selectors
+
+The desktop layout uses `DrawerVariant.Mini` (always-visible icon rail, expands on hover). Nav link text is hidden visually in collapsed state using the **visually-hidden CSS pattern** (not `display: none`):
+
+```css
+.mud-drawer--closed.mud-drawer-mini .mud-nav-link-text {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+}
+```
+
+**Why this matters for tests:** `display: none` removes text from the accessibility tree, breaking `GetByRole(AriaRole.Link, new() { Name = "Entries" })`. The visually-hidden pattern keeps text in the accessibility tree so role-based locators work in both collapsed and expanded rail states.
+
+On desktop, nav links are always in the DOM — **no drawer opening required** before clicking them. On mobile, the hamburger opens a `DrawerVariant.Temporary` overlay.
 
 ---
 

--- a/docs/playwright-strategy.md
+++ b/docs/playwright-strategy.md
@@ -323,6 +323,18 @@ Key points:
 
 `<DefaultTimeout>120000</DefaultTimeout>` in `playwright.runsettings` is NUnit's **per-test wall-clock limit** — it is NOT Playwright's action/assertion timeout. These are completely separate systems. Playwright's timeout is controlled by `Page.SetDefaultTimeout()`. Do not confuse the two.
 
+### --blame-hang-timeout 60s — process-level kill switch
+
+`Browser.CloseAsync()` is called by Playwright's internal `WorkerAwareTest.WorkerTeardown` with no timeout. When a CDP action times out and leaves the connection in a stuck state, `Browser.CloseAsync()` hangs indefinitely — our `PageTearDownAsync` WaitAsync cap does not reach this call.
+
+`--blame-hang-timeout 60s` is a dotnet test CLI flag that force-kills the entire test host process (and child processes) if any single test including its teardown exceeds the timeout. Since `SetDefaultTimeout(30_000)` caps each Playwright action at 30s and `PageTearDownAsync` caps at 10s, 60s gives 20s of buffer before the process is killed.
+
+Always include this flag:
+
+```bash
+PLAYWRIGHT_WRITE_TESTS=true BROWSER= dotnet test TimeTracker.Playwright --logger "console;verbosity=normal" --blame-hang-timeout 60s
+```
+
 ---
 
 ## Nav rail — desktop selectors


### PR DESCRIPTION
## Summary

- Replaces `DrawerVariant.Persistent` hidden drawer with `DrawerVariant.Mini` navigation rail on desktop/tablet — always-visible 56px icon strip, expands on hover
- `DrawerVariant.Temporary` (full overlay) retained on mobile; hamburger hidden on desktop via `MudHidden`
- `IBrowserViewportService` / `IBrowserViewportObserver` drives responsive variant switching at runtime
- Drawer footer removed (logout moved to avatar dropdown in PR #147)
- Nav link text hidden with visually-hidden CSS pattern (not `display:none`) so Playwright role-based locators work in collapsed state
- Playwright test suite fixed for nav rail; `HangDiagnosticTests` preserved as `[Explicit]` fixture
- Playwright hang root causes investigated and fixed: pipe-buffer deadlock in `GlobalSetup.TearDown`, Playwright driver disposal ordering in `AuthenticateAsync`, `--blame-hang-timeout 60s` added as process-level safety net

## Test plan

- [x] `dotnet test TimeTracker.Tests` — 164 unit tests pass
- [x] Playwright suite — 61/61 pass
- [ ] Manual: desktop (1280px) — mini rail visible, expands on hover, no hamburger
- [ ] Manual: mobile (390px) — no rail, hamburger opens full drawer, bottom nav unchanged

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)