### PR TITLE
fix: add /entries fallback route to prevent 404

### DIFF
--- a/TimeTracker.Client/Features/TimeEntries/Pages/TimeEntriesPage.razor
+++ b/TimeTracker.Client/Features/TimeEntries/Pages/TimeEntriesPage.razor
@@ -1,3 +1,4 @@
+@page "/entries"
 @page "/entries/{Tab}"
 @attribute [Authorize]
 @inject ITimeEntryService TimeEntryService


### PR DESCRIPTION
Fixes 404 when navigating to bare `/entries` URL (e.g. from nav bar) after issue #148 added the required `{Tab}` route parameter.

Adds `@page "/entries"` alongside `@page "/entries/{Tab}"` so that bare `/entries` is matched and redirected to `/entries/day` via `OnParametersSet`.

164/164 tests pass.