### PR TITLE
Add revenue display and year navigation to reports (#164, #165)

### DIFF
--- a/TimeTracker.Client/Features/Reports/Pages/ReportsPage.razor
+++ b/TimeTracker.Client/Features/Reports/Pages/ReportsPage.razor
@@ -9,9 +9,17 @@
 
 <div class="pa-4">
     <MudText Typo="Typo.h6" Class="mb-1">Reports</MudText>
-    <MudText Typo="Typo.body2" Style="color:var(--mud-palette-text-secondary)" Class="mb-4">
-        Year overview · @year
-    </MudText>
+    <div class="d-flex align-center gap-2 mb-4">
+        <MudIconButton Icon="@Icons.Material.Filled.ChevronLeft" Size="Size.Small"
+                       OnClick="@(() => NavigateYear(-1))" aria-label="Previous year" />
+        <MudText Typo="Typo.body2" Style="color:var(--mud-palette-text-secondary); min-width:3.5rem; text-align:center">
+            @year
+        </MudText>
+        <MudIconButton Icon="@Icons.Material.Filled.ChevronRight" Size="Size.Small"
+                       OnClick="@(() => NavigateYear(1))"
+                       Disabled="@(year >= DateTime.Today.Year)"
+                       aria-label="Next year" />
+    </div>
 
     @* ── KPI cards ── *@
     <div class="kpi-grid mb-4">
@@ -112,7 +120,7 @@
 <div class="bottom-nav-spacer"></div>
 
 @code {
-    private readonly int year = DateTime.Today.Year;
+    private int year = DateTime.Today.Year;
     private ReportsCalculations.ReportsData? data;
 
     private readonly string[] monthLabels = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
@@ -122,7 +130,15 @@
         ChartPalette = ["#9e9e9e", "#2e7d32", "#0068CD"]
     };
 
-    protected override async Task OnInitializedAsync()
+    protected override Task OnInitializedAsync() => LoadDataAsync();
+
+    private async Task NavigateYear(int delta)
+    {
+        year += delta;
+        await LoadDataAsync();
+    }
+
+    private async Task LoadDataAsync()
     {
         try
         {

--- a/TimeTracker.Client/Features/Reports/Pages/ReportsPage.razor
+++ b/TimeTracker.Client/Features/Reports/Pages/ReportsPage.razor
@@ -26,10 +26,28 @@
         </MudCard>
         <MudCard Outlined="true">
             <MudCardContent Style="padding:16px">
-                <MudText Typo="Typo.overline">Uninvoiced</MudText>
+                <MudText Typo="Typo.overline">YTD earned</MudText>
+                <MudText Class="tabnum" Color="Color.Secondary"
+                         Style="font-size:1.8rem; font-weight:500">
+                    <span Style="font-size:1rem">$</span>@data?.YtdEarned.ToString("N0")
+                </MudText>
+            </MudCardContent>
+        </MudCard>
+        <MudCard Outlined="true">
+            <MudCardContent Style="padding:16px">
+                <MudText Typo="Typo.overline">Uninvoiced hours</MudText>
                 <MudText Class="tabnum" Color="Color.Primary"
                          Style="font-size:1.8rem; font-weight:500">
                     @data?.UninvoicedTotal<span Style="font-size:1rem">h</span>
+                </MudText>
+            </MudCardContent>
+        </MudCard>
+        <MudCard Outlined="true">
+            <MudCardContent Style="padding:16px">
+                <MudText Typo="Typo.overline">Uninvoiced amount</MudText>
+                <MudText Class="tabnum" Color="Color.Primary"
+                         Style="font-size:1.8rem; font-weight:500">
+                    <span Style="font-size:1rem">$</span>@data?.UninvoicedAmount.ToString("N0")
                 </MudText>
             </MudCardContent>
         </MudCard>
@@ -69,9 +87,17 @@
                                     @(row.Project.ClientName ?? row.Project.Name)
                                 </MudText>
                             </div>
-                            <MudText Typo="Typo.body2" Class="tabnum" Style="font-weight:500">
-                                @row.Hours<span Style="font-size:.75rem">h</span>
-                            </MudText>
+                            <div class="d-flex align-center gap-3">
+                                @if (row.Revenue > 0)
+                                {
+                                    <MudText Typo="Typo.body2" Class="tabnum" Style="color:var(--mud-palette-text-secondary)">
+                                        $@row.Revenue.ToString("N0")
+                                    </MudText>
+                                }
+                                <MudText Typo="Typo.body2" Class="tabnum" Style="font-weight:500">
+                                    @row.Hours<span Style="font-size:.75rem">h</span>
+                                </MudText>
+                            </div>
                         </div>
                         <MudProgressLinear Value="@(data.MaxProjectHours > 0 ? (double)row.Hours / data.MaxProjectHours * 100 : 0)"
                                            Color="Color.Primary"

--- a/TimeTracker.Client/Features/Reports/Pages/ReportsPage.razor
+++ b/TimeTracker.Client/Features/Reports/Pages/ReportsPage.razor
@@ -9,13 +9,13 @@
 
 <div class="pa-4">
     <MudText Typo="Typo.h6" Class="mb-1">Reports</MudText>
-    <div class="d-flex align-center gap-2 mb-4">
-        <MudIconButton Icon="@Icons.Material.Filled.ChevronLeft" Size="Size.Small"
+    <div class="d-flex align-center justify-space-between mb-4">
+        <MudIconButton Icon="@Icons.Material.Filled.ChevronLeft"
                        OnClick="@(() => NavigateYear(-1))" aria-label="Previous year" />
-        <MudText Typo="Typo.body2" Style="color:var(--mud-palette-text-secondary); min-width:3.5rem; text-align:center">
+        <MudText Typo="Typo.body2" Style="color:var(--mud-palette-text-secondary); flex:1; text-align:center">
             @year
         </MudText>
-        <MudIconButton Icon="@Icons.Material.Filled.ChevronRight" Size="Size.Small"
+        <MudIconButton Icon="@Icons.Material.Filled.ChevronRight"
                        OnClick="@(() => NavigateYear(1))"
                        Disabled="@(year >= DateTime.Today.Year)"
                        aria-label="Next year" />

--- a/TimeTracker.Contracts/Features/Reports/ReportsCalculations.cs
+++ b/TimeTracker.Contracts/Features/Reports/ReportsCalculations.cs
@@ -5,14 +5,16 @@ namespace TimeTracker.Contracts.Features.Reports;
 
 public static class ReportsCalculations
 {
-    public record ProjectRow(ProjectResponse Project, int Hours);
+    public record ProjectRow(ProjectResponse Project, int Hours, decimal Revenue);
 
     public record ReportsData(
         double YtdTotal,
         double UninvoicedTotal,
         double[][] MonthlyHours,
         List<ProjectRow> ProjectRows,
-        int MaxProjectHours
+        int MaxProjectHours,
+        decimal YtdEarned,
+        decimal UninvoicedAmount
     );
 
     public static ReportsData Compute(List<TimeEntryResponse> entries, List<ProjectResponse> projects)
@@ -22,10 +24,26 @@ public static class ReportsCalculations
         var ytdTotal = Math.Round(completed.Sum(e => (e.End!.Value - e.Start).TotalHours), 1);
 
         var billableIds = projects.Where(p => p.HourlyRate is > 0).Select(p => p.Id).ToHashSet();
+        var projectRates = projects.ToDictionary(p => p.Id, p => p.HourlyRate);
+
+        // Revenue uses EffectiveRate (award rate where applicable) falling back to project HourlyRate.
+        // Invoiced revenue uses current HourlyRate since the rate at invoice time is not stored.
+        decimal EntryRevenue(TimeEntryResponse e)
+        {
+            var hours = (decimal)(e.End!.Value - e.Start).TotalHours;
+            var rate = e.EffectiveRate ?? (projectRates.GetValueOrDefault(e.Project.Id) ?? 0);
+            return hours * rate;
+        }
 
         var uninvoicedTotal = Math.Round(
             completed.Where(e => billableIds.Contains(e.Project.Id) && string.IsNullOrEmpty(e.InvoiceReference))
                      .Sum(e => (e.End!.Value - e.Start).TotalHours), 1);
+
+        var ytdEarned = Math.Round(completed.Sum(EntryRevenue), 2);
+
+        var uninvoicedAmount = Math.Round(
+            completed.Where(e => string.IsNullOrEmpty(e.InvoiceReference))
+                     .Sum(EntryRevenue), 2);
 
         double MonthHours(int m, Func<TimeEntryResponse, bool> predicate) =>
             Math.Round(completed.Where(e => e.Start.Month == m && predicate(e))
@@ -46,13 +64,16 @@ public static class ReportsCalculations
             .Select(p => new ProjectRow(p,
                 (int)Math.Round(completed
                     .Where(e => e.Project.Id == p.Id)
-                    .Sum(e => (e.End!.Value - e.Start).TotalHours))))
+                    .Sum(e => (e.End!.Value - e.Start).TotalHours)),
+                Math.Round(completed
+                    .Where(e => e.Project.Id == p.Id)
+                    .Sum(EntryRevenue), 2)))
             .Where(r => r.Hours > 0)
             .OrderByDescending(r => r.Hours)
             .ToList();
 
         var maxProjectHours = projectRows.Count > 0 ? projectRows.Max(r => r.Hours) : 1;
 
-        return new ReportsData(ytdTotal, uninvoicedTotal, monthlyHours, projectRows, maxProjectHours);
+        return new ReportsData(ytdTotal, uninvoicedTotal, monthlyHours, projectRows, maxProjectHours, ytdEarned, uninvoicedAmount);
     }
 }

--- a/TimeTracker.Tests/Features/Reports/ReportsCalculationsTests.cs
+++ b/TimeTracker.Tests/Features/Reports/ReportsCalculationsTests.cs
@@ -11,8 +11,8 @@ public class ReportsCalculationsTests
     private static readonly int Year = DateTime.Today.Year;
 
     private static TimeEntryResponse MakeEntry(int projectId, DateTime start, DateTime end,
-        string? invoiceRef = null) =>
-        new(0, new ProjectSummary(projectId, $"Project {projectId}"), start, end, null, invoiceRef, null);
+        string? invoiceRef = null, decimal? effectiveRate = null) =>
+        new(0, new ProjectSummary(projectId, $"Project {projectId}"), start, end, null, invoiceRef, null, effectiveRate);
 
     private static TimeEntryResponse MakeRunning(int projectId) =>
         new(0, new ProjectSummary(projectId, $"Project {projectId}"), DateTime.Now, null, null, null, null);
@@ -158,5 +158,127 @@ public class ReportsCalculationsTests
         var result = ReportsCalculations.Compute(entries, projects);
 
         Assert.Equal(5, result.MaxProjectHours);
+    }
+
+    // --- Revenue ---
+
+    [Fact]
+    public void YtdEarned_IsHoursTimesHourlyRate()
+    {
+        var entries = new List<TimeEntryResponse>
+        {
+            MakeEntry(1, new DateTime(Year, 1, 1, 9, 0, 0), new DateTime(Year, 1, 1, 11, 0, 0)), // 2h × $100
+            MakeEntry(1, new DateTime(Year, 2, 1, 9, 0, 0), new DateTime(Year, 2, 1, 10, 30, 0)), // 1.5h × $100
+        };
+        var projects = new List<ProjectResponse> { MakeProject(1, hourlyRate: 100) };
+
+        var result = ReportsCalculations.Compute(entries, projects);
+
+        Assert.Equal(350m, result.YtdEarned);
+    }
+
+    [Fact]
+    public void YtdEarned_ExcludesNonBillableEntries()
+    {
+        var entries = new List<TimeEntryResponse>
+        {
+            MakeEntry(1, new DateTime(Year, 1, 1, 9, 0, 0), new DateTime(Year, 1, 1, 11, 0, 0)), // billable
+            MakeEntry(2, new DateTime(Year, 1, 1, 9, 0, 0), new DateTime(Year, 1, 1, 11, 0, 0)), // non-billable
+        };
+        var projects = new List<ProjectResponse>
+        {
+            MakeProject(1, hourlyRate: 100),
+            MakeProject(2, hourlyRate: null),
+        };
+
+        var result = ReportsCalculations.Compute(entries, projects);
+
+        Assert.Equal(200m, result.YtdEarned);
+    }
+
+    [Fact]
+    public void YtdEarned_UsesEffectiveRateOverHourlyRate()
+    {
+        var entries = new List<TimeEntryResponse>
+        {
+            MakeEntry(1, new DateTime(Year, 1, 1, 9, 0, 0), new DateTime(Year, 1, 1, 11, 0, 0), effectiveRate: 150m), // 2h × $150 award rate
+        };
+        var projects = new List<ProjectResponse> { MakeProject(1, hourlyRate: 100) };
+
+        var result = ReportsCalculations.Compute(entries, projects);
+
+        Assert.Equal(300m, result.YtdEarned);
+    }
+
+    [Fact]
+    public void UninvoicedAmount_OnlyCountsEntriesWithNoInvoiceRef()
+    {
+        var entries = new List<TimeEntryResponse>
+        {
+            MakeEntry(1, new DateTime(Year, 1, 1, 9, 0, 0), new DateTime(Year, 1, 1, 11, 0, 0)),                      // 2h uninvoiced
+            MakeEntry(1, new DateTime(Year, 1, 2, 9, 0, 0), new DateTime(Year, 1, 2, 11, 0, 0), invoiceRef: "INV-1"), // 2h invoiced
+        };
+        var projects = new List<ProjectResponse> { MakeProject(1, hourlyRate: 100) };
+
+        var result = ReportsCalculations.Compute(entries, projects);
+
+        Assert.Equal(200m, result.UninvoicedAmount);
+    }
+
+    [Fact]
+    public void UninvoicedAmount_ExcludesNonBillableEntries()
+    {
+        var entries = new List<TimeEntryResponse>
+        {
+            MakeEntry(1, new DateTime(Year, 1, 1, 9, 0, 0), new DateTime(Year, 1, 1, 11, 0, 0)), // billable, no invoice
+            MakeEntry(2, new DateTime(Year, 1, 1, 9, 0, 0), new DateTime(Year, 1, 1, 11, 0, 0)), // non-billable, no invoice
+        };
+        var projects = new List<ProjectResponse>
+        {
+            MakeProject(1, hourlyRate: 100),
+            MakeProject(2, hourlyRate: null),
+        };
+
+        var result = ReportsCalculations.Compute(entries, projects);
+
+        Assert.Equal(200m, result.UninvoicedAmount);
+    }
+
+    [Fact]
+    public void ProjectRow_Revenue_IsHoursTimesRate()
+    {
+        var entries = new List<TimeEntryResponse>
+        {
+            MakeEntry(1, new DateTime(Year, 1, 1, 9, 0, 0), new DateTime(Year, 1, 1, 11, 0, 0)), // 2h × $75
+            MakeEntry(1, new DateTime(Year, 1, 2, 9, 0, 0), new DateTime(Year, 1, 2, 10, 0, 0)), // 1h × $75
+        };
+        var projects = new List<ProjectResponse> { MakeProject(1, hourlyRate: 75) };
+
+        var result = ReportsCalculations.Compute(entries, projects);
+
+        Assert.Equal(225m, result.ProjectRows[0].Revenue);
+    }
+
+    [Fact]
+    public void ProjectRow_Revenue_IsZeroForNonBillableProject()
+    {
+        var entries = new List<TimeEntryResponse>
+        {
+            MakeEntry(1, new DateTime(Year, 1, 1, 9, 0, 0), new DateTime(Year, 1, 1, 11, 0, 0)),
+        };
+        var projects = new List<ProjectResponse> { MakeProject(1, hourlyRate: null) };
+
+        var result = ReportsCalculations.Compute(entries, projects);
+
+        Assert.Equal(0m, result.ProjectRows[0].Revenue);
+    }
+
+    [Fact]
+    public void EmptyEntries_ReturnsZeroRevenue()
+    {
+        var result = ReportsCalculations.Compute([], []);
+
+        Assert.Equal(0m, result.YtdEarned);
+        Assert.Equal(0m, result.UninvoicedAmount);
     }
 }


### PR DESCRIPTION
## Summary

- **#164 Revenue display**: Adds 4 KPI cards (YTD hours, YTD earned, uninvoiced hours, uninvoiced amount), per-project revenue in the breakdown, and the underlying `YtdEarned` / `UninvoicedAmount` calculations to `ReportsCalculations`. Uses `EffectiveRate` (award rate) where present, falling back to project `HourlyRate`.
- **#165 Year navigation**: Replaces the static year subtitle with prev/next chevron buttons. The forward button is disabled on the current year. Data loading is extracted to `LoadDataAsync()` so it re-fetches on year change.

## Changes

- `TimeTracker.Contracts/Features/Reports/ReportsCalculations.cs` — added `Revenue` to `ProjectRow`, added `YtdEarned` and `UninvoicedAmount` to `ReportsData`, added `EntryRevenue` local function
- `TimeTracker.Client/Features/Reports/Pages/ReportsPage.razor` — 4 KPI cards, per-project revenue, year stepper UI, `LoadDataAsync()` extracted
- `TimeTracker.Tests/Features/Reports/ReportsCalculationsTests.cs` — updated `MakeEntry` helper with optional `effectiveRate`; added 8 revenue tests

## Test plan

- [ ] `dotnet test TimeTracker.Tests` passes (includes new revenue calculation tests)
- [ ] `dotnet test TimeTracker.ComponentTests` passes
- [ ] Reports page loads showing current year data with 4 KPI cards
- [ ] Left chevron navigates to a prior year and data reloads
- [ ] Right chevron is disabled on the current year
- [ ] Per-project revenue shows in grey next to hours for billable projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hYFziPA1RAd8GLdNJUWqG

---
_Generated by [Claude Code](https://claude.ai/code/session_011hYFziPA1RAd8GLdNJUWqG)_