### PR TITLE
Upgrade bunit 1.38.5 → 2.7.2 and fix breaking API changes (fixes #175)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,27 @@ When a Playwright test fails, answer these two questions FIRST. Do not touch any
 
 Full strategy and wait patterns: `docs/playwright-strategy.md`.
 
+## Dependency management
+
+### Dependabot
+
+Dependabot runs weekly (Monday) for NuGet and GitHub Actions packages.
+
+**EF Core packages must always be upgraded together.** They have a tight lock-step version requirement: upgrading only one package causes `NU1605` (package downgrade as error) because the upgraded package pulls in a newer `Microsoft.EntityFrameworkCore.Relational`, which then requires a newer `Microsoft.EntityFrameworkCore` than what the other projects still pin. A Dependabot `group` named `entity-framework-core` in `.github/dependabot.yml` ensures all EF Core packages are bundled into one PR automatically. If you ever need to upgrade EF Core manually, update all of these in one commit across all three projects (Web, Tests, Shared):
+- `Microsoft.EntityFrameworkCore`
+- `Microsoft.EntityFrameworkCore.SqlServer`
+- `Microsoft.EntityFrameworkCore.Design`
+- `Microsoft.AspNetCore.Identity.EntityFrameworkCore`
+- `Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore`
+- `Microsoft.EntityFrameworkCore.InMemory` (Tests only)
+
+### bUnit upgrades
+
+bUnit follows semantic versioning strictly. Major version bumps (e.g. 1.x → 2.x) are breaking. Known breaking changes when upgrading to bUnit 2.x:
+- `RenderComponent<T>()` → `Render<T>()` (all call sites in test files and `MudBlazorContext`)
+- `TestContext` → `BunitContext` (kept as `[Obsolete]` shim in 2.x)
+- `MudBlazorContext` must implement `IAsyncLifetime` so xUnit uses async teardown — MudBlazor services (`PopoverService`, `KeyInterceptorService`) are `IAsyncDisposable`-only and throw if synchronously disposed. See `TimeTracker.ComponentTests/Fixtures/MudBlazorContext.cs` for the pattern.
+
 ## Git discipline
 
 NEVER blow away uncommitted changes. Always commit or stash before switching branches, pulling, or doing any operation that might overwrite local changes. If you find yourself with a large pile of uncommitted changes, stop and deal with that first before writing new code.

--- a/TimeTracker.ComponentTests/Features/Projects/ProjectCardTests.cs
+++ b/TimeTracker.ComponentTests/Features/Projects/ProjectCardTests.cs
@@ -19,7 +19,7 @@ public class ProjectCardTests : MudBlazorContext
     public void RendersProjectName()
     {
         var project = MakeProject(name: "Acme Website");
-        var cut = RenderComponent<ProjectCard>(p => p.Add(c => c.Project, project));
+        var cut = Render<ProjectCard>(p => p.Add(c => c.Project, project));
 
         Assert.Contains("Acme Website", cut.Markup);
     }
@@ -28,7 +28,7 @@ public class ProjectCardTests : MudBlazorContext
     public void RendersClientName_WhenSet()
     {
         var project = MakeProject(clientName: "Acme Corp");
-        var cut = RenderComponent<ProjectCard>(p => p.Add(c => c.Project, project));
+        var cut = Render<ProjectCard>(p => p.Add(c => c.Project, project));
 
         Assert.Contains("Acme Corp", cut.Markup);
     }
@@ -37,7 +37,7 @@ public class ProjectCardTests : MudBlazorContext
     public void RendersNoClient_WhenClientNameIsNull()
     {
         var project = MakeProject(clientName: null);
-        var cut = RenderComponent<ProjectCard>(p => p.Add(c => c.Project, project));
+        var cut = Render<ProjectCard>(p => p.Add(c => c.Project, project));
 
         Assert.Contains("No client", cut.Markup);
     }
@@ -46,7 +46,7 @@ public class ProjectCardTests : MudBlazorContext
     public void RendersHourlyRateChip_WhenRateIsSet()
     {
         var project = MakeProject(hourlyRate: 150m);
-        var cut = RenderComponent<ProjectCard>(p => p.Add(c => c.Project, project));
+        var cut = Render<ProjectCard>(p => p.Add(c => c.Project, project));
 
         Assert.Contains("150", cut.Markup);
         Assert.Contains("/h", cut.Markup);
@@ -56,7 +56,7 @@ public class ProjectCardTests : MudBlazorContext
     public void RendersInternalChip_WhenRateIsNull()
     {
         var project = MakeProject(hourlyRate: null);
-        var cut = RenderComponent<ProjectCard>(p => p.Add(c => c.Project, project));
+        var cut = Render<ProjectCard>(p => p.Add(c => c.Project, project));
 
         Assert.Contains("internal", cut.Markup);
     }
@@ -65,7 +65,7 @@ public class ProjectCardTests : MudBlazorContext
     public void RendersInternalChip_WhenRateIsZero()
     {
         var project = MakeProject(hourlyRate: 0m);
-        var cut = RenderComponent<ProjectCard>(p => p.Add(c => c.Project, project));
+        var cut = Render<ProjectCard>(p => p.Add(c => c.Project, project));
 
         Assert.Contains("internal", cut.Markup);
     }
@@ -74,7 +74,7 @@ public class ProjectCardTests : MudBlazorContext
     public void RendersStartDate_WhenSet()
     {
         var project = MakeProject(startDate: new DateTime(2025, 3, 1));
-        var cut = RenderComponent<ProjectCard>(p => p.Add(c => c.Project, project));
+        var cut = Render<ProjectCard>(p => p.Add(c => c.Project, project));
 
         Assert.Contains("Mar 2025", cut.Markup);
     }
@@ -83,7 +83,7 @@ public class ProjectCardTests : MudBlazorContext
     public void RendersDashPlaceholder_WhenStartDateIsNull()
     {
         var project = MakeProject(startDate: null);
-        var cut = RenderComponent<ProjectCard>(p => p.Add(c => c.Project, project));
+        var cut = Render<ProjectCard>(p => p.Add(c => c.Project, project));
 
         Assert.Contains("since —", cut.Markup);
     }
@@ -92,7 +92,7 @@ public class ProjectCardTests : MudBlazorContext
     public void AppliesProjectColour_FromProjectId()
     {
         var project = MakeProject(id: 3);
-        var cut = RenderComponent<ProjectCard>(p => p.Add(c => c.Project, project));
+        var cut = Render<ProjectCard>(p => p.Add(c => c.Project, project));
 
         var expectedColour = ProjectColors.ForProject(3);
         Assert.Contains(expectedColour, cut.Markup);
@@ -102,7 +102,7 @@ public class ProjectCardTests : MudBlazorContext
     public void RendersYtdHours_WhenProvided()
     {
         var project = MakeProject();
-        var cut = RenderComponent<ProjectCard>(p => p
+        var cut = Render<ProjectCard>(p => p
             .Add(c => c.Project, project)
             .Add(c => c.YtdHours, 42));
 
@@ -114,7 +114,7 @@ public class ProjectCardTests : MudBlazorContext
     {
         int? receivedId = null;
         var project = MakeProject(id: 7);
-        var cut = RenderComponent<ProjectCard>(p => p
+        var cut = Render<ProjectCard>(p => p
             .Add(c => c.Project, project)
             .Add(c => c.OnOpen, EventCallback.Factory.Create<int>(this, id => receivedId = id)));
 

--- a/TimeTracker.ComponentTests/Features/TimeEntries/EntryRowTests.cs
+++ b/TimeTracker.ComponentTests/Features/TimeEntries/EntryRowTests.cs
@@ -26,7 +26,7 @@ public class EntryRowTests : MudBlazorContext
     public void RendersProjectName_WhenShowProjectIsTrue()
     {
         var entry = MakeEntry(projectName: "Acme Corp");
-        var cut = RenderComponent<EntryRow>(p => p
+        var cut = Render<EntryRow>(p => p
             .Add(e => e.Entry, entry)
             .Add(e => e.ShowProject, true));
 
@@ -37,7 +37,7 @@ public class EntryRowTests : MudBlazorContext
     public void RendersNote_WhenShowProjectIsFalse()
     {
         var entry = MakeEntry(note: "Design review");
-        var cut = RenderComponent<EntryRow>(p => p
+        var cut = Render<EntryRow>(p => p
             .Add(e => e.Entry, entry)
             .Add(e => e.ShowProject, false));
 
@@ -48,7 +48,7 @@ public class EntryRowTests : MudBlazorContext
     public void RendersFallback_WhenShowProjectIsFalseAndNoteIsEmpty()
     {
         var entry = MakeEntry(note: null);
-        var cut = RenderComponent<EntryRow>(p => p
+        var cut = Render<EntryRow>(p => p
             .Add(e => e.Entry, entry)
             .Add(e => e.ShowProject, false));
 
@@ -61,7 +61,7 @@ public class EntryRowTests : MudBlazorContext
         var start = new DateTime(2026, 1, 1, 9, 0, 0, DateTimeKind.Utc);
         var end = new DateTime(2026, 1, 1, 10, 30, 0, DateTimeKind.Utc);
         var entry = MakeEntry(start: start, end: end);
-        var cut = RenderComponent<EntryRow>(p => p.Add(e => e.Entry, entry));
+        var cut = Render<EntryRow>(p => p.Add(e => e.Entry, entry));
 
         Assert.Contains("1h 30m", cut.Markup);
     }
@@ -72,7 +72,7 @@ public class EntryRowTests : MudBlazorContext
         var start = new DateTime(2026, 1, 1, 9, 0, 0, DateTimeKind.Utc);
         var end = new DateTime(2026, 1, 1, 9, 45, 0, DateTimeKind.Utc);
         var entry = MakeEntry(start: start, end: end);
-        var cut = RenderComponent<EntryRow>(p => p.Add(e => e.Entry, entry));
+        var cut = Render<EntryRow>(p => p.Add(e => e.Entry, entry));
 
         // Check the duration text element specifically — checking cut.Markup would match
         // SVG path data (e.g. d="M0 0h24v24H0z") which also contains "h" substrings.
@@ -84,7 +84,7 @@ public class EntryRowTests : MudBlazorContext
     public void RendersInvoiceIcon_WhenInvoiceReferenceIsSet()
     {
         var entry = MakeEntry(invoiceRef: "INV-2026-001");
-        var cut = RenderComponent<EntryRow>(p => p.Add(e => e.Entry, entry));
+        var cut = Render<EntryRow>(p => p.Add(e => e.Entry, entry));
 
         // MudTooltip renders its text in the popover portal, not inline in the component —
         // check the component instance's Text parameter instead.
@@ -96,7 +96,7 @@ public class EntryRowTests : MudBlazorContext
     public void DoesNotRenderInvoiceIcon_WhenNoInvoiceReference()
     {
         var entry = MakeEntry(invoiceRef: null, isAwardRate: false);
-        var cut = RenderComponent<EntryRow>(p => p.Add(e => e.Entry, entry));
+        var cut = Render<EntryRow>(p => p.Add(e => e.Entry, entry));
 
         // No tooltips should be rendered when neither invoice ref nor award rate is set
         Assert.Empty(cut.FindComponents<MudTooltip>());
@@ -106,7 +106,7 @@ public class EntryRowTests : MudBlazorContext
     public void RendersAwardRateChip_WhenIsAwardRateIsTrue()
     {
         var entry = MakeEntry(isAwardRate: true);
-        var cut = RenderComponent<EntryRow>(p => p.Add(e => e.Entry, entry));
+        var cut = Render<EntryRow>(p => p.Add(e => e.Entry, entry));
 
         Assert.Contains("AW", cut.Markup);
     }
@@ -115,7 +115,7 @@ public class EntryRowTests : MudBlazorContext
     public void DoesNotRenderAwardRateChip_WhenIsAwardRateIsFalse()
     {
         var entry = MakeEntry(isAwardRate: false);
-        var cut = RenderComponent<EntryRow>(p => p.Add(e => e.Entry, entry));
+        var cut = Render<EntryRow>(p => p.Add(e => e.Entry, entry));
 
         Assert.DoesNotContain("AW", cut.Markup);
     }
@@ -124,7 +124,7 @@ public class EntryRowTests : MudBlazorContext
     public void AppliesProjectColour_FromProjectId()
     {
         var entry = MakeEntry(projectId: 1);
-        var cut = RenderComponent<EntryRow>(p => p.Add(e => e.Entry, entry));
+        var cut = Render<EntryRow>(p => p.Add(e => e.Entry, entry));
 
         var expectedColour = ProjectColors.ForProject(1);
         Assert.Contains(expectedColour, cut.Markup);
@@ -135,7 +135,7 @@ public class EntryRowTests : MudBlazorContext
     {
         TimeEntryResponse? received = null;
         var entry = MakeEntry();
-        var cut = RenderComponent<EntryRow>(p => p
+        var cut = Render<EntryRow>(p => p
             .Add(e => e.Entry, entry)
             .Add(e => e.OnEdit, EventCallback.Factory.Create<TimeEntryResponse>(this, r => received = r)));
 

--- a/TimeTracker.ComponentTests/Fixtures/MudBlazorContext.cs
+++ b/TimeTracker.ComponentTests/Fixtures/MudBlazorContext.cs
@@ -3,7 +3,13 @@ using MudBlazor;
 
 namespace TimeTracker.ComponentTests.Fixtures;
 
-public abstract class MudBlazorContext : TestContext
+// IAsyncLifetime tells xUnit to call DisposeAsync() (async teardown) rather than Dispose()
+// (sync teardown). This is required because MudBlazor services (PopoverService,
+// KeyInterceptorService) moved to IAsyncDisposable-only in MudBlazor 9.x, and bunit's sync
+// Dispose() path throws InvalidOperationException when it encounters them. DisposeAsync()
+// disposes the DI container async-safely; the subsequent sync Dispose() call that xUnit also
+// makes is then a no-op (the container is already marked disposed).
+public abstract class MudBlazorContext : BunitContext, IAsyncLifetime
 {
     protected MudBlazorContext()
     {
@@ -19,6 +25,10 @@ public abstract class MudBlazorContext : TestContext
 
         // MudTooltip, MudMenu, and other popover-based components require MudPopoverProvider
         // to be present in the render tree before they can render.
-        RenderComponent<MudPopoverProvider>();
+        Render<MudPopoverProvider>();
     }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public new async Task DisposeAsync() => await ((IAsyncDisposable)this).DisposeAsync();
 }

--- a/TimeTracker.ComponentTests/TimeTracker.ComponentTests.csproj
+++ b/TimeTracker.ComponentTests/TimeTracker.ComponentTests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="bunit" Version="1.38.5" />
+    <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Why the Dependabot PR failed

bunit 2.0 is a major release with breaking changes. The CI failure had two causes:

### 1. `RenderComponent<T>()` → `Render<T>()` (CS0619 compile error)

bunit 2.x promotes the obsolete warning on `RenderComponent` to a compiler error. All 23 call sites in `EntryRowTests`, `ProjectCardTests`, and `MudBlazorContext` have been updated.

### 2. `TestContext` → `BunitContext` (CS0618 warning)

`TestContext` is kept as an `[Obsolete]` shim. Updated `MudBlazorContext` to extend `BunitContext` directly.

### 3. MudBlazor async-disposal incompatibility (runtime failure)

`MudBlazor.PopoverService` and `KeyInterceptorService` are registered as `IAsyncDisposable`-only in MudBlazor 9.x. bunit's synchronous teardown path (`BunitContext.Dispose()`) calls `BunitServiceProvider.Dispose()`, which throws `InvalidOperationException` when it encounters these services.

**Fix**: `MudBlazorContext` now implements xUnit's `IAsyncLifetime` interface. xUnit calls `IAsyncLifetime.DisposeAsync()` first, which delegates to `BunitContext`'s own `IAsyncDisposable.DisposeAsync()` — properly awaiting every async-only service. The sync `Dispose()` call that xUnit makes afterward finds the container already disposed and exits cleanly.

The fixture comment explains all three points so the next person upgrading bunit knows what to expect.

## Test plan

- [ ] `dotnet test TimeTracker.ComponentTests` — 22 tests pass, zero warnings

Closes #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hYFziPA1RAd8GLdNJUWqG

---
_Generated by [Claude Code](https://claude.ai/code/session_011hYFziPA1RAd8GLdNJUWqG)_