### PR TITLE
chore: consolidate Dependabot package upgrades

### DIFF
--- a/TimeTracker.ComponentTests/TimeTracker.ComponentTests.csproj
+++ b/TimeTracker.ComponentTests/TimeTracker.ComponentTests.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TimeTracker.Playwright/TimeTracker.Playwright.csproj
+++ b/TimeTracker.Playwright/TimeTracker.Playwright.csproj
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="Microsoft.Playwright.Xunit" Version="1.52.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.Playwright.Xunit" Version="1.60.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TimeTracker.Tests/TimeTracker.Tests.csproj
+++ b/TimeTracker.Tests/TimeTracker.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TimeTracker.Web/TimeTracker.Web.csproj
+++ b/TimeTracker.Web/TimeTracker.Web.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.9" />
     <PackageReference Include="MudBlazor" Version="9.5.0" />
     <PackageReference Include="PublicHoliday" Version="3.13.0" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.5.3" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.16.4" />
     <PackageReference Include="Mapster" Version="10.0.8" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.2" />


### PR DESCRIPTION
Replaces Dependabot PRs #182, #183, #184, #185, #186 — all touched overlapping `.csproj` files and could not be merged independently.

## Changes

| Package | From | To | Projects |
|---------|------|----|----------|
| `Microsoft.NET.Test.Sdk` | 17.14.0 | 18.6.0 | ComponentTests, Playwright |
| `Microsoft.Playwright.Xunit` | 1.52.0 | 1.60.0 | Playwright |
| `xunit.runner.visualstudio` | 2.8.2 | 3.1.5 | Tests, ComponentTests, Playwright |
| `Xunit.SkippableFact` | 1.4.13 | 1.5.61 | Playwright |
| `Scalar.AspNetCore` | 2.5.3 | 2.16.4 | Web |

## Test plan
- [x] `dotnet build TimeTracker.sln` — clean
- [x] `dotnet test TimeTracker.Tests` — 172 passed
- [x] `dotnet test TimeTracker.ComponentTests` — 22 passed
- [ ] Playwright E2E (user to run after merge)

**Note:** `Microsoft.Playwright.Xunit` 1.60.0 includes updated browser binaries. Run `pwsh playwright install chromium` locally after merging to update the installed browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)