### PR TITLE
feat: add Testcontainers for RLS and migration smoke tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,11 +37,21 @@ PLAYWRIGHT_WRITE_TESTS=true BROWSER= dotnet test TimeTracker.sln --logger "conso
 ```
 Prerequisite: SQL Server running, user secrets set (`DbUser`, `DbPassword`). **Local only — not available in remote sessions.**
 
-**During development** (fast feedback, no DB or browser needed):
+**During development** (fast feedback, no DB or Docker needed):
+```bash
+dotnet test TimeTracker.Tests --filter "Category!=Container" && dotnet test TimeTracker.ComponentTests
+```
+Works in remote sessions. The `Category!=Container` filter excludes Testcontainers-based tests (RLS + migration smoke tests), which require Docker.
+
+**Container tests only** (requires Docker locally or CI):
+```bash
+dotnet test TimeTracker.Tests --filter "Category=Container"
+```
+
+**All unit + container tests** (requires Docker):
 ```bash
 dotnet test TimeTracker.Tests && dotnet test TimeTracker.ComponentTests
 ```
-Works in remote sessions (no SQL Server or browser required).
 
 **Hang diagnostic only** (not part of normal suite):
 ```bash

--- a/README.md
+++ b/README.md
@@ -75,10 +75,16 @@ API docs (dev only): `https://localhost:7006/scalar/v1`
 
 ## Testing
 
-### Unit tests
+### Unit tests (fast — no Docker needed)
 
 ```bash
-dotnet test TimeTracker.Tests
+dotnet test TimeTracker.Tests --filter "Category!=Container" && dotnet test TimeTracker.ComponentTests
+```
+
+### Container tests (RLS + migration smoke — requires Docker)
+
+```bash
+dotnet test TimeTracker.Tests --filter "Category=Container"
 ```
 
 ### Playwright E2E tests

--- a/SESSION.md
+++ b/SESSION.md
@@ -1,36 +1,48 @@
-# Session handoff — 2026-06-22
+# Session handoff — 2026-06-23
 
 ## Completed this session
-- ✅ **#187 Dependabot batch** — consolidated 5 conflicting Dependabot PRs into one:
-  - `Microsoft.NET.Test.Sdk` 17.14.0 → 18.6.0
-  - `Microsoft.Playwright.Xunit` 1.52.0 → 1.60.0
-  - `xunit.runner.visualstudio` 2.8.2 → 3.1.5
-  - `Xunit.SkippableFact` 1.4.13 → 1.5.61
-  - `Scalar.AspNetCore` 2.5.3 → 2.16.4
-- ✅ **#188 Showcase CSS sync + smoke tests** (issue #159):
-  - Deleted `showcase-app.css`; MSBuild now copies `app.css` from `TimeTracker.Web` directly
-  - `ShowcaseFixture` + `ShowcaseTests` — 7 smoke tests, all passing
-  - Root cause of `.dat` 404: `UseStaticFiles` silently refuses unknown MIME types; fixed with `ServeUnknownFileTypes = true`
-  - `docs/playwright-strategy.md` → `docs/testing-strategy.md` (3 parts: E2E, Showcase, bUnit)
+- ✅ **#161 Testcontainers for RLS and migration tests** — `SqlServerFixture` collection fixture starts one SQL Server container per session; `RlsIntegrationTests` rewritten (env var guards removed, runs in CI); `MigrationSmokeTests` added for both EF contexts; `[Trait("Category", "Container")]` filter keeps fast loop Docker-free. **PR not yet raised.**
 
 ## Standard test commands
 **Before every PR:**
 ```bash
 PLAYWRIGHT_WRITE_TESTS=true BROWSER= dotnet test TimeTracker.sln --logger "console;verbosity=normal" --blame-hang-timeout 60s
 ```
-**Showcase tests only:**
+**Fast (no Docker or browser):**
+```bash
+dotnet test TimeTracker.Tests --filter "Category!=Container" && dotnet test TimeTracker.ComponentTests
+```
+**Container tests only (requires Docker):**
+```bash
+dotnet test TimeTracker.Tests --filter "Category=Container"
+```
+**Showcase smoke tests:**
 ```bash
 BROWSER= dotnet test TimeTracker.Playwright --filter "FullyQualifiedName~ShowcaseTests" --logger "console;verbosity=normal" --blame-hang-timeout 60s
 ```
-**During development (fast):**
-```bash
-dotnet test TimeTracker.Tests && dotnet test TimeTracker.ComponentTests
-```
 
-## Backlog
-- **#96** 🟢 Staging environment (requires paid tier upgrade)
-- **#102** 🟢 Email/password fallback + TOTP MFA
-- **#121** 🟢 OpenTelemetry → Grafana Cloud APM
+## Backlog (from GitHub project board)
+
+### 🟡 Medium
+| # | Title |
+|---|-------|
+| #161 | Add Testcontainers for RLS and migration tests ← **done, PR pending** |
+| #162 | Add dev container and Docker Compose for local development |
+| #166 | CSV export for time entries |
+| #167 | Project budget tracking |
+| #121 | Add distributed tracing and APM via OpenTelemetry and Grafana Cloud |
+
+### 🟢 Low
+| # | Title |
+|---|-------|
+| #168 | Duplicate time entry |
+| #169 | Tags for time entries |
+| #170 | Time rounding rules |
+| #36  | Invoice export — uninvoiced entries per client for Zoho Books |
+| #108 | Run Lighthouse audit and address findings |
+| #163 | Define Azure infrastructure as code with Bicep |
+| #102 | Add email/password login fallback and TOTP MFA |
+| #96  | Add staging environment (requires paid tier upgrade) |
 
 ## Active tech debt
 | # | Item | ADR |
@@ -52,4 +64,4 @@ cat SESSION.md
 ```
 
 ---
-*Updated 2026-06-22. Both PRs merged. Main is clean.*
+*Updated 2026-06-23. Branch `feature/161-testcontainers-rls-migration` committed, PR not yet raised.*

--- a/TimeTracker.Tests/Infrastructure/MigrationSmokeTests.cs
+++ b/TimeTracker.Tests/Infrastructure/MigrationSmokeTests.cs
@@ -1,0 +1,37 @@
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using TimeTracker.Web.Data;
+using Xunit;
+
+namespace TimeTracker.Tests.Infrastructure;
+
+/// <summary>
+/// Verifies that EF Core migrations for both DbContexts apply cleanly from scratch.
+/// Each test creates an isolated, empty database on the shared SQL Server container
+/// and calls MigrateAsync() — if any migration is broken, the test fails before it
+/// reaches production.
+/// </summary>
+[Collection("SqlServer")]
+[Trait("Category", "Container")]
+public class MigrationSmokeTests(SqlServerFixture fixture)
+{
+    [Fact]
+    public async Task TimeTrackerDataContext_migrations_apply_cleanly()
+    {
+        var opts = new DbContextOptionsBuilder<TimeTrackerDataContext>()
+            .UseSqlServer(fixture.CreateIsolatedConnectionString())
+            .Options;
+        await using var ctx = new TimeTrackerDataContext(opts);
+        await ctx.Database.MigrateAsync();
+    }
+
+    [Fact]
+    public async Task IdentityDataContext_migrations_apply_cleanly()
+    {
+        var opts = new DbContextOptionsBuilder<IdentityDataContext>()
+            .UseSqlServer(fixture.CreateIsolatedConnectionString())
+            .Options;
+        await using var ctx = new IdentityDataContext(opts);
+        await ctx.Database.MigrateAsync();
+    }
+}

--- a/TimeTracker.Tests/Infrastructure/RlsIntegrationTests.cs
+++ b/TimeTracker.Tests/Infrastructure/RlsIntegrationTests.cs
@@ -10,49 +10,32 @@ namespace TimeTracker.Tests.Infrastructure;
 /// Verifies that SQL Server Row-Level Security filter predicates enforce data isolation
 /// even when the application service layer is bypassed entirely (raw DbContext queries).
 ///
-/// These tests connect as a dedicated low-privilege SQL login that holds only
+/// These tests use a Testcontainers SQL Server instance (started once per session by
+/// SqlServerFixture) so they run in CI and locally without any manual DB setup.
+///
+/// Tests connect as a dedicated low-privilege SQL login that holds only
 /// db_datareader + db_datawriter — the same role as the production Managed Identity.
-/// 'sa' / db_owner users are exempt from RLS by SQL Server design; these tests would
-/// trivially pass for them, which is why they use a separate unprivileged connection.
-///
-/// HOW TO RUN LOCALLY:
-///   1. Ensure the app is configured with a running local SQL Server and migrations applied.
-///   2. Set these environment variables:
-///        SQL_SERVER_RLS_TESTS=true
-///        SQL_SERVER_ADMIN_CONNECTION=Server=localhost,1435;Database=TimeTrackerDb;User Id=sa;Password=<pwd>;TrustServerCertificate=true
-///        SQL_SERVER_APP_CONNECTION=Server=localhost,1435;Database=TimeTrackerDb;TrustServerCertificate=true
-///      (The admin connection is used only for setup/teardown of the test login.)
-///   3. dotnet test --filter "FullyQualifiedName~RlsIntegrationTests"
-///
-/// These tests are always skipped in CI — they are local validation that RLS policies
-/// are correctly applied in a real SQL Server environment.
+/// SA / db_owner users are exempt from RLS by SQL Server design; using a separate
+/// unprivileged connection ensures the policy is actually exercised.
 /// </summary>
-[Collection("RlsIntegration")]
-public class RlsIntegrationTests
+[Collection("SqlServer")]
+[Trait("Category", "Container")]
+public class RlsIntegrationTests(SqlServerFixture fixture)
 {
     private const string TestLoginName = "timetracker_rls_test";
     private const string TestLoginPassword = "Rls_T3st!Pw#2026";
     private const string UserA = "user-rls-A";
     private const string UserB = "user-rls-B";
 
-    private static bool RlsTestsEnabled =>
-        Environment.GetEnvironmentVariable("SQL_SERVER_RLS_TESTS") == "true";
-
-    private static string? AdminConnection =>
-        Environment.GetEnvironmentVariable("SQL_SERVER_ADMIN_CONNECTION");
-
-    private static string? AppConnectionTemplate =>
-        Environment.GetEnvironmentVariable("SQL_SERVER_APP_CONNECTION");
-
-    private static string AppConnectionAsTestUser =>
-        new SqlConnectionStringBuilder(AppConnectionTemplate)
+    private string AppConnectionAsTestUser =>
+        new SqlConnectionStringBuilder(fixture.AdminConnectionString)
         {
             UserID = TestLoginName,
             Password = TestLoginPassword,
             IntegratedSecurity = false,
         }.ConnectionString;
 
-    private static DbContextOptions<TimeTrackerDataContext> OptionsForTestUser() =>
+    private DbContextOptions<TimeTrackerDataContext> OptionsForTestUser() =>
         new DbContextOptionsBuilder<TimeTrackerDataContext>()
             .UseSqlServer(AppConnectionAsTestUser)
             .Options;
@@ -60,8 +43,6 @@ public class RlsIntegrationTests
     [Fact]
     public async Task TimeEntries_UserA_CannotSeeUserB_Entries()
     {
-        if (!RlsTestsEnabled) return; // opt-in only — set SQL_SERVER_RLS_TESTS=true to run locally
-
         await using var setup = await SetupAsync();
 
         await using var ctx = new TimeTrackerDataContext(OptionsForTestUser());
@@ -76,8 +57,6 @@ public class RlsIntegrationTests
     [Fact]
     public async Task Projects_UserA_CannotSeeUserB_Projects()
     {
-        if (!RlsTestsEnabled) return; // opt-in only — set SQL_SERVER_RLS_TESTS=true to run locally
-
         await using var setup = await SetupAsync();
 
         await using var ctx = new TimeTrackerDataContext(OptionsForTestUser());
@@ -95,8 +74,6 @@ public class RlsIntegrationTests
     [Fact]
     public async Task ProjectUsers_UserA_CannotSeeUserB_Memberships()
     {
-        if (!RlsTestsEnabled) return; // opt-in only — set SQL_SERVER_RLS_TESTS=true to run locally
-
         await using var setup = await SetupAsync();
 
         await using var ctx = new TimeTrackerDataContext(OptionsForTestUser());
@@ -108,10 +85,10 @@ public class RlsIntegrationTests
         Assert.DoesNotContain(visible, pu => pu.UserId == UserB);
     }
 
-    // Seeds test data as admin (sa bypasses RLS) and creates the unprivileged test login.
-    private static async Task<RlsTestSetup> SetupAsync()
+    // Seeds test data as SA (bypasses RLS) and creates the unprivileged test login.
+    private async Task<RlsTestSetup> SetupAsync()
     {
-        await using var adminConn = new SqlConnection(AdminConnection);
+        await using var adminConn = new SqlConnection(fixture.AdminConnectionString);
         await adminConn.OpenAsync();
 
         // Create the low-privilege test login if it doesn't already exist.
@@ -128,7 +105,7 @@ public class RlsIntegrationTests
 
         // Seed data using admin connection (bypasses RLS — intentional).
         var adminOptions = new DbContextOptionsBuilder<TimeTrackerDataContext>()
-            .UseSqlServer(AdminConnection)
+            .UseSqlServer(fixture.AdminConnectionString)
             .Options;
 
         await using var ctx = new TimeTrackerDataContext(adminOptions);
@@ -177,7 +154,18 @@ public class RlsIntegrationTests
                 await ctx.TimeEntries.Where(e => e.UserId == UserA || e.UserId == UserB).ToListAsync());
             ctx.ProjectUsers.RemoveRange(
                 await ctx.ProjectUsers.Where(pu => pu.UserId == UserA || pu.UserId == UserB).ToListAsync());
-            ctx.Projects.RemoveRange(ProjectA, ProjectB);
+
+            // Re-query projects fresh rather than using the stale entity references from SetupAsync.
+            // The stale objects carry their ProjectUsers navigation collection; attaching them would cause
+            // EF to generate cascade-delete commands for ProjectUsers that are already gone (deleted above),
+            // resulting in DbUpdateConcurrencyException (0 rows affected).
+            // IgnoreAutoIncludes() prevents EF loading the navigation; IgnoreQueryFilters() bypasses soft-delete.
+            var projects = await ctx.Projects
+                .IgnoreAutoIncludes()
+                .IgnoreQueryFilters()
+                .Where(p => p.Id == ProjectA.Id || p.Id == ProjectB.Id)
+                .ToListAsync();
+            ctx.Projects.RemoveRange(projects);
             await ctx.SaveChangesAsync();
         }
     }

--- a/TimeTracker.Tests/Infrastructure/SqlServerFixture.cs
+++ b/TimeTracker.Tests/Infrastructure/SqlServerFixture.cs
@@ -1,0 +1,71 @@
+using DotNet.Testcontainers.Builders;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Testcontainers.MsSql;
+using TimeTracker.Web.Data;
+using Xunit;
+
+namespace TimeTracker.Tests.Infrastructure;
+
+[CollectionDefinition("SqlServer")]
+public class SqlServerCollection : ICollectionFixture<SqlServerFixture> { }
+
+/// <summary>
+/// Starts a single SQL Server container per test session and applies both EF Core
+/// migrations so that every test in the [Collection("SqlServer")] collection shares
+/// one pre-migrated database instance.
+///
+/// Tests that need an isolated, empty database (e.g. migration smoke tests) should
+/// call CreateIsolatedConnectionString() to spin up a fresh database on the same
+/// container rather than using the shared AdminConnectionString directly.
+/// </summary>
+public class SqlServerFixture : IAsyncLifetime
+{
+    private readonly MsSqlContainer _container = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest")
+        .WithAutoRemove(true)
+        .Build();
+
+    /// <summary>
+    /// SA-level connection string to the shared, pre-migrated database.
+    /// Use this in tests that need to seed or inspect data (e.g. RLS tests).
+    /// </summary>
+    public string AdminConnectionString { get; private set; } = string.Empty;
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+        AdminConnectionString = _container.GetConnectionString();
+        await ApplyMigrationsAsync(AdminConnectionString);
+    }
+
+    public Task DisposeAsync() => _container.DisposeAsync().AsTask();
+
+    /// <summary>
+    /// Returns a connection string pointing to a freshly created, empty database
+    /// on the same container. Useful for migration smoke tests that need to verify
+    /// migrations apply cleanly from scratch without touching the shared DB.
+    /// </summary>
+    public string CreateIsolatedConnectionString()
+    {
+        var builder = new SqlConnectionStringBuilder(AdminConnectionString)
+        {
+            InitialCatalog = $"isolated_{Guid.NewGuid():N}"
+        };
+        return builder.ConnectionString;
+    }
+
+    private static async Task ApplyMigrationsAsync(string connectionString)
+    {
+        var trackerOpts = new DbContextOptionsBuilder<TimeTrackerDataContext>()
+            .UseSqlServer(connectionString)
+            .Options;
+        await using var trackerCtx = new TimeTrackerDataContext(trackerOpts);
+        await trackerCtx.Database.MigrateAsync();
+
+        var identityOpts = new DbContextOptionsBuilder<IdentityDataContext>()
+            .UseSqlServer(connectionString)
+            .Options;
+        await using var identityCtx = new IdentityDataContext(identityOpts);
+        await identityCtx.Database.MigrateAsync();
+    }
+}

--- a/TimeTracker.Tests/TimeTracker.Tests.csproj
+++ b/TimeTracker.Tests/TimeTracker.Tests.csproj
@@ -9,7 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,7 +42,7 @@ TimeTracker.sln
 ├── TimeTracker.Client      — Blazor WASM client: all routed pages, layouts, HTTP services
 ├── TimeTracker.Contracts   — Shared DTOs and interfaces (referenced by both Web and Client)
 ├── TimeTracker.Shared      — EF Core entities only (referenced by Web only)
-├── TimeTracker.Tests            — xUnit unit tests (EF InMemory, no running DB required)
+├── TimeTracker.Tests            — xUnit unit tests: fast/InMemory + container category (Testcontainers SQL Server, requires Docker)
 ├── TimeTracker.ComponentTests   — xUnit + bUnit Blazor component tests (in-memory renderer, no browser)
 └── TimeTracker.Playwright       — xUnit + Playwright E2E browser tests
 ```
@@ -239,7 +239,7 @@ Application Insights is not included (pay-as-you-go, no free monthly allowance o
 | CI/CD | GitHub Actions — OIDC push-to-deploy | Free |
 | Structured logging | Serilog → stdout (Azure App Service log stream) | Free |
 | Uptime monitoring | UptimeRobot free tier → `/health` endpoint | Free |
-| Tests | 186 tests: 164 service integration (EF InMemory) + 22 bUnit component tests | — |
+| Tests | 196 tests: 169 service (EF InMemory fast) + 5 Testcontainers container (RLS + migration smoke) + 22 bUnit component | — |
 | Remote development | Claude Code on the web — `.claude/hooks/session-start.sh` installs .NET 10 + builds on session start | Free |
 
 ---

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -28,6 +28,8 @@ Architectural decisions that were non-obvious, had meaningful alternatives, or a
 | [D022](#d022-ef-core-migrateAsync-at-startup) | EF Core `MigrateAsync()` at startup | 2026-06 | Accepted |
 | [D025](#d025-publicholiday-for-au-public-holiday-resolution) | `PublicHoliday` for AU public holiday resolution | 2026-06 | Accepted |
 | [D026](#d026-xunit-over-nunit-for-playwright--new-bunit-component-layer) | xUnit over NUnit for Playwright + new bUnit component layer | 2026-06 | Accepted |
+| [D027](#d027-showcase-css-unified-via-msbuild) | Showcase CSS unified via MSBuild | 2026-06 | Accepted |
+| [D028](#d028-testcontainers-for-rls-and-migration-smoke-tests) | Testcontainers for RLS and migration smoke tests | 2026-06 | Accepted |
 
 ---
 
@@ -703,3 +705,28 @@ The structural problem: two files with no automated link. Every CSS change requi
 - ✅ MSBuild cross-project file reference is standard and supported; no custom build targets needed
 - ✅ Showcase smoke tests (Part 2 of `docs/testing-strategy.md`) catch broken routing and rendering regressions
 - ❌ Showcase always gets all CSS even if a feature is hidden behind `#if SHOWCASE`; acceptable trade-off (unused CSS has zero visible effect)
+
+---
+
+## D028: Testcontainers for RLS and migration smoke tests
+
+**Date:** 2026-06 — **Status:** Accepted — **Issue:** [#161](https://github.com/zkarachiwala/TimeTracker/issues/161)
+
+**Context:** `RlsIntegrationTests` required three environment variables and silently passed (via early return) in CI and remote sessions — RLS policy correctness was never automatically verified. There was also no automated check that EF Core migrations applied cleanly; a broken migration would only fail at production deploy time.
+
+Both problems share the same root cause: the tests needed a real SQL Server instance but had no portable way to get one. Testcontainers is also a widely-used industry pattern for database-integration testing, and learning it here is a direct transferable skill — an additional reason to adopt it even on a personal app where the coverage gap could have been tolerated.
+
+**Decision:** Add `Testcontainers.MsSql` to `TimeTracker.Tests`. A `SqlServerFixture` (`ICollectionFixture<SqlServerFixture>`) starts one SQL Server container per test session, applies both EF migrations (setup for RLS tests), and exposes the admin connection string. Container-dependent tests are tagged `[Trait("Category", "Container")]` so the fast development loop remains Docker-free. CI (`ubuntu-latest`) has Docker — container tests run there without any infrastructure changes.
+
+**Alternatives considered:**
+- **Env var opt-in (status quo):** Silent green in CI; no real coverage guarantee.
+- **Separate `TimeTracker.ContainerTests` project:** Cleaner isolation, but more project setup overhead and a third test command to maintain. Not worth it for five tests.
+- **Accept Docker in the fast loop:** Simpler (no trait filter), but breaks fast feedback in remote Claude Code sessions where Docker is unavailable.
+
+**Consequences:**
+- ✅ RLS policy correctness is verified in CI on every PR — no silent skips
+- ✅ Both EF migration chains (`TimeTrackerDataContext` + `IdentityDataContext`) are smoke-tested from scratch
+- ✅ Fast dev loop (`--filter "Category!=Container"`) remains Docker-free for remote sessions
+- ✅ `[Trait("Category", "Container")]` is idiomatic xUnit and scales to any future Docker-dependent tests
+- ❌ First CI run pulls the SQL Server 2022 Docker image (~1.5 GB); cached on subsequent runs
+- ❌ Container startup adds ~10–20 s to the full test run (not the filtered fast run)

--- a/docs/testcontainers.md
+++ b/docs/testcontainers.md
@@ -1,0 +1,227 @@
+# Testcontainers in TimeTracker
+
+## What is Testcontainers?
+
+Testcontainers is a .NET library that starts real Docker containers from inside your test code. You write C#, call `container.StartAsync()`, and you get a fully working SQL Server (or Redis, or Postgres, or anything with a Docker image) running locally — no pre-installed service, no env vars, no manual setup.
+
+The key insight: **the test controls the infrastructure, not the other way around.** You don't configure your machine to have SQL Server running; your test starts it on demand and tears it down when it's done.
+
+---
+
+## Why we added it
+
+Two problems existed before this change:
+
+1. **RLS tests were permanently skipped in CI.** `RlsIntegrationTests` required three env vars (`SQL_SERVER_RLS_TESTS=true`, admin connection string, app connection string) and only ran when you manually set them. This meant row-level security could silently break without anyone knowing.
+
+2. **Broken migrations only surfaced at deploy time.** There was no automated check that EF Core migrations applied cleanly. A bad migration would reach Azure and fail during startup.
+
+Both problems have the same root cause: the tests needed SQL Server but had no portable way to get it. Testcontainers solves this.
+
+---
+
+## How the fixture works
+
+The entry point is `SqlServerFixture` in `TimeTracker.Tests/Infrastructure/SqlServerFixture.cs`.
+
+```csharp
+public class SqlServerFixture : IAsyncLifetime
+{
+    private readonly MsSqlContainer _container = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest")
+        .WithAutoRemove(true)
+        .Build();
+
+    public string AdminConnectionString { get; private set; } = string.Empty;
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+        AdminConnectionString = _container.GetConnectionString();
+        await ApplyMigrationsAsync(AdminConnectionString);
+    }
+
+    public Task DisposeAsync() => _container.DisposeAsync().AsTask();
+}
+```
+
+**`IAsyncLifetime`** is an xUnit interface. xUnit calls `InitializeAsync()` before any test in the collection runs, and `DisposeAsync()` after all of them finish. This is the lifecycle hook that lets a fixture own expensive resources.
+
+**`MsSqlBuilder`** is the Testcontainers fluent API for SQL Server. Under the hood it:
+1. Pulls the `mcr.microsoft.com/mssql/server` Docker image (cached after the first pull)
+2. Starts a container with a randomly assigned host port
+3. Waits until SQL Server is ready to accept connections (it polls the health endpoint)
+4. Returns a connection string like `Server=localhost,54321;Database=master;User Id=sa;Password=...`
+
+You don't need to know the port — `GetConnectionString()` gives it to you.
+
+**`WithAutoRemove(true)`** tells Docker to delete the container when the process exits, even if `DisposeAsync` didn't run (e.g. the test runner crashed). Belt-and-suspenders cleanup.
+
+---
+
+## xUnit collection fixtures — how sharing works
+
+The fixture is expensive to start (~10–20 seconds for SQL Server to initialise). You don't want to pay that cost once per test class. xUnit's **collection fixture** pattern lets multiple test classes share one fixture instance.
+
+```csharp
+[CollectionDefinition("SqlServer")]
+public class SqlServerCollection : ICollectionFixture<SqlServerFixture> { }
+```
+
+`CollectionDefinition` is a marker class — it has no tests, no body, just attributes. It declares that a collection called `"SqlServer"` exists and that its shared fixture is `SqlServerFixture`.
+
+Any test class that opts into this collection gets the shared instance:
+
+```csharp
+[Collection("SqlServer")]
+public class RlsIntegrationTests(SqlServerFixture fixture) { ... }
+
+[Collection("SqlServer")]
+public class MigrationSmokeTests(SqlServerFixture fixture) { ... }
+```
+
+xUnit creates one `SqlServerFixture`, calls `InitializeAsync` once, injects it into both test classes via primary constructor parameters, then calls `DisposeAsync` once when both classes finish. The container runs for the duration of the entire test session, not per test.
+
+---
+
+## The `[Trait]` filter
+
+```csharp
+[Trait("Category", "Container")]
+```
+
+This is xUnit metadata — a key/value tag you can filter on at the command line:
+
+```bash
+# Skip container tests (fast, no Docker needed)
+dotnet test TimeTracker.Tests --filter "Category!=Container"
+
+# Run only container tests
+dotnet test TimeTracker.Tests --filter "Category=Container"
+```
+
+This is important because Testcontainers needs Docker. In remote Claude Code sessions, Docker isn't available — so the fast feedback command excludes container tests. CI (ubuntu-latest) has Docker, so CI runs everything.
+
+The trait is on the class, not individual methods — all tests in the class inherit it.
+
+---
+
+## Migration smoke tests
+
+`MigrationSmokeTests` verifies that both EF Core migration chains apply cleanly from scratch.
+
+```csharp
+[Fact]
+public async Task TimeTrackerDataContext_migrations_apply_cleanly()
+{
+    var opts = new DbContextOptionsBuilder<TimeTrackerDataContext>()
+        .UseSqlServer(fixture.CreateIsolatedConnectionString())
+        .Options;
+    await using var ctx = new TimeTrackerDataContext(opts);
+    await ctx.Database.MigrateAsync();
+}
+```
+
+**Why `CreateIsolatedConnectionString()`?** The shared fixture already applied migrations to the base database. If we just tested against that, we'd be verifying that migrations were already applied — not that they *can* apply. To test migrations properly, we need a fresh empty database. `CreateIsolatedConnectionString()` generates a connection string with a unique `InitialCatalog` name (a GUID), pointing to the same container. When `MigrateAsync()` runs against a non-existent database, EF Core creates it and applies every migration from the beginning.
+
+```csharp
+public string CreateIsolatedConnectionString()
+{
+    var builder = new SqlConnectionStringBuilder(AdminConnectionString)
+    {
+        InitialCatalog = $"isolated_{Guid.NewGuid():N}"
+    };
+    return builder.ConnectionString;
+}
+```
+
+If a migration is malformed (bad SQL, missing column, wrong FK), `MigrateAsync` throws and the test fails. This catches migration bugs before they reach Azure.
+
+---
+
+## RLS tests — what changed
+
+The original `RlsIntegrationTests` used:
+
+```csharp
+private static bool RlsTestsEnabled =>
+    Environment.GetEnvironmentVariable("SQL_SERVER_RLS_TESTS") == "true";
+
+[Fact]
+public async Task TimeEntries_UserA_CannotSeeUserB_Entries()
+{
+    if (!RlsTestsEnabled) return; // silently skip
+    ...
+}
+```
+
+Silent skips are dangerous — the test always shows green in CI even though it never ran.
+
+Now the test class takes the fixture as a constructor parameter. No guard, no env var. If Docker is available, the test runs and actually verifies something. If Docker isn't available (remote session), the `--filter "Category!=Container"` flag excludes it entirely — a skip that's explicit and intentional, not silent.
+
+The test logic itself didn't change. The connection string now comes from the fixture:
+
+```csharp
+// Before: AdminConnection = Environment.GetEnvironmentVariable("SQL_SERVER_ADMIN_CONNECTION");
+// After:
+private string AppConnectionAsTestUser =>
+    new SqlConnectionStringBuilder(fixture.AdminConnectionString) { ... }.ConnectionString;
+```
+
+The SA connection the fixture exposes has the same role as the old `SQL_SERVER_ADMIN_CONNECTION` — it bypasses RLS because SA is db_owner. The low-privilege login (`timetracker_rls_test`) is still created in `SetupAsync` using that SA connection, giving us a realistic representation of the production Managed Identity role.
+
+---
+
+## Docker image caching
+
+The first time these tests run, Docker has to pull `mcr.microsoft.com/mssql/server` (~1.5 GB). This is slow. After the first pull, Docker caches the image locally and subsequent runs start in seconds.
+
+In CI (GitHub Actions), the image is re-pulled on every run unless you configure Docker layer caching. For this project that's acceptable — the total CI time cost is modest and the simplicity is worth it.
+
+---
+
+## A subtle EF Core pitfall: stale navigation properties across contexts
+
+During development, the `DisposeAsync` cleanup hit a `DbUpdateConcurrencyException` that illustrates a common EF Core trap worth understanding.
+
+The original cleanup code passed entity objects across DbContext boundaries:
+
+```csharp
+// SetupAsync creates ProjectA/ProjectB in context #1
+var projectA = new Project { ..., ProjectUsers = [new ProjectUser { UserId = UserA }] };
+ctx.Projects.AddRange(projectA, projectB);
+await ctx.SaveChangesAsync(); // context #1 tracks these
+
+// DisposeAsync uses context #2 — but passes the stale entity from context #1
+await using var ctx = new TimeTrackerDataContext(adminOptions); // context #2
+ctx.Projects.RemoveRange(ProjectA, ProjectB); // ProjectA still has ProjectUsers loaded!
+```
+
+When you attach an entity to a new context, EF also attaches everything reachable via navigation properties. `ProjectA.ProjectUsers` still contained the `ProjectUser` object that was created in `SetupAsync`. EF generated a CASCADE DELETE for it — but we'd already explicitly deleted those `ProjectUsers` two lines earlier. The DELETE found 0 rows and EF threw `DbUpdateConcurrencyException`.
+
+The fix: re-query the projects fresh in the cleanup context using `IgnoreAutoIncludes()`. This gives EF clean instances with no navigation state, so it generates a simple `DELETE WHERE Id = X` rather than trying to cascade:
+
+```csharp
+var projects = await ctx.Projects
+    .IgnoreAutoIncludes()   // don't load ProjectUsers navigation
+    .IgnoreQueryFilters()   // bypass soft-delete global filter
+    .Where(p => p.Id == ProjectA.Id || p.Id == ProjectB.Id)
+    .ToListAsync();
+ctx.Projects.RemoveRange(projects);
+```
+
+**General rule:** never pass entity objects loaded by one `DbContext` into a different `DbContext` instance for mutation. Either keep the same context, or re-query what you need in the new context.
+
+---
+
+## When to reach for Testcontainers
+
+Use it when:
+- Your test needs a real database (not InMemory) to verify SQL Server-specific behaviour — RLS policies, indexed views, triggers, stored procedures
+- You want to verify that migrations apply cleanly
+- You're testing something that depends on database constraints (FK, unique indexes) that InMemory ignores
+
+Don't use it when:
+- You're testing business logic that doesn't depend on the database engine — InMemory is faster and simpler for that
+- You need the test to run without Docker (remote sessions, restricted CI environments)
+
+The cost of Testcontainers is startup time (~10–20s for SQL Server). Keep the container-dependent tests focused on things that genuinely require a real engine.


### PR DESCRIPTION
## Summary

- Adds `Testcontainers.MsSql` to `TimeTracker.Tests` — one SQL Server container starts per test session via `SqlServerFixture` (`ICollectionFixture`)
- Rewrites `RlsIntegrationTests` to use the container fixture — env var opt-in guards removed, tests now run automatically in CI
- Adds `MigrationSmokeTests` — verifies both `TimeTrackerDataContext` and `IdentityDataContext` migrations apply cleanly from scratch on every PR
- Container-dependent tests tagged `[Trait("Category", "Container")]` so the fast dev loop stays Docker-free (`--filter "Category!=Container"`)
- Updates `CLAUDE.md`, `README.md`, `docs/architecture.md`, `docs/decisions.md` (D028), and adds `docs/testcontainers.md` learning doc

## Test plan

- [ ] `dotnet test TimeTracker.Tests --filter "Category!=Container"` — 169 passed, no Docker needed
- [ ] `dotnet test TimeTracker.Tests --filter "Category=Container"` — 5 passed (3 RLS + 2 migration smoke)
- [ ] CI passes on this PR

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)