### PR TITLE
feat: add dev container and Docker Compose for local development (#162)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "TimeTracker Dev Container",
+  "dockerComposeFile": ["../docker-compose.yml"],
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "forwardPorts": [5019],
+  "postCreateCommand": "dotnet restore TimeTracker.sln && dotnet ef database update --project TimeTracker.Web --context TimeTrackerDataContext && dotnet ef database update --project TimeTracker.Web --context IdentityDataContext",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csdevkit",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,14 +3,32 @@
   "dockerComposeFile": ["../docker-compose.yml"],
   "service": "app",
   "workspaceFolder": "/workspace",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:latest": {}
+  },
+  "mounts": [
+    "source=${localEnv:HOME}/.microsoft/usersecrets,target=/home/vscode/.microsoft/usersecrets,type=bind,consistency=cached,readonly"
+  ],
   "forwardPorts": [5019],
-  "postCreateCommand": "dotnet restore TimeTracker.sln && dotnet ef database update --project TimeTracker.Web --context TimeTrackerDataContext && dotnet ef database update --project TimeTracker.Web --context IdentityDataContext",
+  "portsAttributes": {
+    "5019": {
+      "label": "TimeTracker App",
+      "onAutoForward": "notify"
+    }
+  },
+  "postCreateCommand": "dotnet tool install --global dotnet-ef && dotnet restore TimeTracker.sln && dotnet ef database update --project TimeTracker.Web --context TimeTrackerDataContext && dotnet ef database update --project TimeTracker.Web --context IdentityDataContext",
+  "postStartCommand": "cd TimeTracker.Web && dotnet run --launch-profile container",
   "customizations": {
     "vscode": {
       "extensions": [
         "ms-dotnettools.csdevkit",
-        "ms-azuretools.vscode-docker"
-      ]
+        "ms-azuretools.vscode-docker",
+        "ms-mssql.mssql"
+      ],
+      "settings": {
+        "editor.formatOnSave": true
+      }
     }
-  }
+  },
+  "remoteUser": "vscode"
 }

--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,13 @@
 # Copy this file to .env and fill in the values. Never commit .env.
+#
+# Google OAuth credentials and AdminEmail come from .NET User Secrets — no duplication needed here.
+# Only the SQL Server credentials are needed because the container DB is separate from your local one.
 
 # SQL Server SA password
 # Must be at least 8 characters and contain: uppercase, lowercase, digit, and symbol
-# Example: MyStr0ng!Pass
 SA_PASSWORD=
 
-# Application database credentials used by the .NET app
-# For a dev container, the simplest approach is to use SA directly:
-#   DB_USER=sa
-#   DB_PASSWORD=<same value as SA_PASSWORD>
+# Application database credentials used by the .NET app to connect to the container SQL Server
+# Simplest approach: use SA directly — DB_USER=sa, DB_PASSWORD=<same as SA_PASSWORD>
 DB_USER=
 DB_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy this file to .env and fill in the values. Never commit .env.
+
+# SQL Server SA password
+# Must be at least 8 characters and contain: uppercase, lowercase, digit, and symbol
+# Example: MyStr0ng!Pass
+SA_PASSWORD=
+
+# Application database credentials used by the .NET app
+# For a dev container, the simplest approach is to use SA directly:
+#   DB_USER=sa
+#   DB_PASSWORD=<same value as SA_PASSWORD>
+DB_USER=
+DB_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -358,3 +358,6 @@ MigrationBackup/
 
 # Local showcase publish output
 .showcase-local/
+
+# Dev container secrets — copy from .env.example and fill in values
+.env

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch TimeTracker",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/TimeTracker.Web/bin/Debug/net10.0/TimeTracker.Web.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/TimeTracker.Web",
+      "stopAtEntry": false,
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_URLS": "http://+:5019"
+      },
+      "serverReadyAction": {
+        "pattern": "\\bNow listening on:\\s+(https?://\\S+)",
+        "uriFormat": "%s",
+        "action": "openExternally"
+      }
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "sarif-viewer.connectToGithubCodeScanning": "off"
+    "sarif-viewer.connectToGithubCodeScanning": "off",
+    "dev.containers.reopenInContainer": "always"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,72 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": ["build", "${workspaceFolder}/TimeTracker.sln"],
+      "problemMatcher": "$msCompile",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared"
+      }
+    },
+    {
+      "label": "run",
+      "command": "dotnet",
+      "type": "process",
+      "args": ["run", "--project", "${workspaceFolder}/TimeTracker.Web", "--launch-profile", "container"],
+      "problemMatcher": [],
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    },
+    {
+      "label": "test: fast",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "test", "${workspaceFolder}/TimeTracker.Tests",
+        "--filter", "Category!=Container",
+        "&&",
+        "dotnet", "test", "${workspaceFolder}/TimeTracker.ComponentTests"
+      ],
+      "problemMatcher": "$msCompile",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "test: container",
+      "command": "dotnet",
+      "type": "process",
+      "args": ["test", "${workspaceFolder}/TimeTracker.Tests", "--filter", "Category=Container"],
+      "problemMatcher": "$msCompile",
+      "group": "test"
+    },
+    {
+      "label": "ef: migrate",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "ef", "database", "update",
+        "--project", "${workspaceFolder}/TimeTracker.Web",
+        "--context", "TimeTrackerDataContext"
+      ],
+      "problemMatcher": [],
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      }
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,21 +38,27 @@ The project includes a VS Code dev container backed by Docker Compose. This is t
 2. Open the repo in VS Code — it will offer to reopen in the container
 3. `postCreateCommand` runs automatically: restores packages and applies EF migrations
 
+**First-time setup:**
+1. Copy `.env.example` to `.env` and fill in `SA_PASSWORD`, `DB_USER`, `DB_PASSWORD`
+2. Open the repo in VS Code — it will offer to reopen in the container
+3. `postCreateCommand` runs automatically: installs EF tools, restores packages, applies migrations
+4. `postStartCommand` runs automatically: starts the app on `http://localhost:5019`
+
 **Running the app inside the container:**
-```bash
-cd TimeTracker.Web && dotnet run --launch-profile http
-```
-App is available at `http://localhost:5019` (forwarded from the container).
 
-**Google OAuth:** Add `http://localhost:5019/signin-google` to Authorized Redirect URIs in Google Cloud Console alongside the production URI. Google explicitly allows `http://localhost` — see `docs/google-oauth-setup.md`.
+The app starts automatically via `postStartCommand` on container start. To restart manually:
+- `Ctrl+Shift+P` → **Tasks: Run Task** → **run**, or press `F5` to launch with debugger attached
 
-**Useful Docker Compose commands (run from host):**
+Do NOT use `--launch-profile https` or `--launch-profile http` inside the container — they bind to `localhost` only (unreachable from outside). The `container` profile uses `http://+:5019` (all interfaces).
+
+**Google OAuth:** Add `http://localhost:5019/signin-google` to Authorized Redirect URIs in Google Cloud Console alongside the production URI. Google credentials come from .NET User Secrets — no `.env` entry needed.
+
+**Useful Docker Compose commands (run from host or container terminal):**
 ```bash
 docker compose up -d          # Start all services
 docker compose down           # Stop (data preserved)
 docker compose down -v        # Stop and wipe volumes (clean slate)
 docker compose logs db        # SQL Server logs
-docker compose logs app       # App container logs
 ```
 
 **Three SQL Server instances in this project** — they serve different purposes and never all run simultaneously:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,37 @@ gh project item-add 1 --owner zkarachiwala --url https://github.com/zkarachiwala
 
 The hook only runs when `CLAUDE_CODE_REMOTE=true` — it is a no-op locally.
 
+## Dev container (primary dev environment)
+
+The project includes a VS Code dev container backed by Docker Compose. This is the preferred development environment — see `docs/devcontainer-guide.md` for full explanation of the concepts.
+
+**First-time setup:**
+1. Copy `.env.example` to `.env` and fill in `SA_PASSWORD`, `DB_USER`, `DB_PASSWORD`
+2. Open the repo in VS Code — it will offer to reopen in the container
+3. `postCreateCommand` runs automatically: restores packages and applies EF migrations
+
+**Running the app inside the container:**
+```bash
+cd TimeTracker.Web && dotnet run --launch-profile http
+```
+App is available at `http://localhost:5019` (forwarded from the container).
+
+**Google OAuth:** Add `http://localhost:5019/signin-google` to Authorized Redirect URIs in Google Cloud Console alongside the production URI. Google explicitly allows `http://localhost` — see `docs/google-oauth-setup.md`.
+
+**Useful Docker Compose commands (run from host):**
+```bash
+docker compose up -d          # Start all services
+docker compose down           # Stop (data preserved)
+docker compose down -v        # Stop and wipe volumes (clean slate)
+docker compose logs db        # SQL Server logs
+docker compose logs app       # App container logs
+```
+
+**Three SQL Server instances in this project** — they serve different purposes and never all run simultaneously:
+- Local SQL Server (existing) — local dev outside the container
+- Dev container SQL Server — inside the dev container (Docker)
+- Testcontainers SQL Server — spun up only during `Category=Container` tests
+
 ## Standard test commands
 
 **Before every PR** — run the full solution (service tests + bUnit + Playwright E2E):

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0
+
+RUN dotnet tool install --global dotnet-ef
+ENV PATH="${PATH}:/root/.dotnet/tools"
+
+WORKDIR /workspace
+CMD ["sleep", "infinity"]

--- a/SESSION.md
+++ b/SESSION.md
@@ -1,7 +1,7 @@
 # Session handoff — 2026-06-23
 
 ## Completed this session
-- ✅ **#161 Testcontainers for RLS and migration tests** — `SqlServerFixture` collection fixture starts one SQL Server container per session; `RlsIntegrationTests` rewritten (env var guards removed, runs in CI); `MigrationSmokeTests` added for both EF contexts; `[Trait("Category", "Container")]` filter keeps fast loop Docker-free. **PR not yet raised.**
+- ✅ **#161 Testcontainers for RLS and migration tests** — `SqlServerFixture` collection fixture starts one SQL Server container per session; `RlsIntegrationTests` rewritten (env var guards removed, runs in CI); `MigrationSmokeTests` added for both EF contexts; `[Trait("Category", "Container")]` filter keeps fast loop Docker-free. **Merged as PR #192.**
 
 ## Standard test commands
 **Before every PR:**
@@ -26,7 +26,7 @@ BROWSER= dotnet test TimeTracker.Playwright --filter "FullyQualifiedName~Showcas
 ### 🟡 Medium
 | # | Title |
 |---|-------|
-| #161 | Add Testcontainers for RLS and migration tests ← **done, PR pending** |
+| ~~#161~~ | ~~Add Testcontainers for RLS and migration tests~~ ← **merged PR #192** |
 | #162 | Add dev container and Docker Compose for local development |
 | #166 | CSV export for time entries |
 | #167 | Project budget tracking |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - "5019:5019"
     volumes:
       - .:/workspace:cached
+      - /home/zkarachiwala/.microsoft/usersecrets:/home/vscode/.microsoft/usersecrets:ro
     working_dir: /workspace
     command: sleep infinity
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+services:
+  db:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      ACCEPT_EULA: "Y"
+      SA_PASSWORD: "${SA_PASSWORD}"
+      MSSQL_PID: Developer
+    ports:
+      - "1433:1433"
+    volumes:
+      - sqlserver_data:/var/opt/mssql
+    healthcheck:
+      test: ["CMD", "/opt/mssql-tools18/bin/sqlcmd", "-S", "localhost",
+             "-U", "sa", "-P", "${SA_PASSWORD}", "-C",
+             "-Q", "SELECT 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: http://+:5019
+      ConnectionStrings__TimeTrackerConnection: "Server=db,1433;Database=TimeTrackerDb;TrustServerCertificate=True"
+      ConnectionStrings__IdentityConnection: "Server=db,1433;Database=TimeTrackerDb;TrustServerCertificate=True"
+      DbUser: "${DB_USER}"
+      DbPassword: "${DB_PASSWORD}"
+    ports:
+      - "5019:5019"
+    volumes:
+      - .:/workspace
+    working_dir: /workspace
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - .env
+
+volumes:
+  sqlserver_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,7 @@ services:
       start_period: 30s
 
   app:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: mcr.microsoft.com/devcontainers/dotnet:dev-10.0-noble
     environment:
       ASPNETCORE_ENVIRONMENT: Development
       ASPNETCORE_URLS: http://+:5019
@@ -32,8 +30,9 @@ services:
     ports:
       - "5019:5019"
     volumes:
-      - .:/workspace
+      - .:/workspace:cached
     working_dir: /workspace
+    command: sleep infinity
     depends_on:
       db:
         condition: service_healthy

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -30,6 +30,8 @@ Architectural decisions that were non-obvious, had meaningful alternatives, or a
 | [D026](#d026-xunit-over-nunit-for-playwright--new-bunit-component-layer) | xUnit over NUnit for Playwright + new bUnit component layer | 2026-06 | Accepted |
 | [D027](#d027-showcase-css-unified-via-msbuild) | Showcase CSS unified via MSBuild | 2026-06 | Accepted |
 | [D028](#d028-testcontainers-for-rls-and-migration-smoke-tests) | Testcontainers for RLS and migration smoke tests | 2026-06 | Accepted |
+| [D029](#d029-dev-container--docker-compose-despite-single-user-app-scope) | Dev container + Docker Compose despite single-user app scope | 2026-06 | Accepted |
+| [D030](#d030-http-only-inside-the-dev-container) | HTTP-only inside the dev container | 2026-06 | Accepted |
 
 ---
 
@@ -730,3 +732,53 @@ Both problems share the same root cause: the tests needed a real SQL Server inst
 - ✅ `[Trait("Category", "Container")]` is idiomatic xUnit and scales to any future Docker-dependent tests
 - ❌ First CI run pulls the SQL Server 2022 Docker image (~1.5 GB); cached on subsequent runs
 - ❌ Container startup adds ~10–20 s to the full test run (not the filtered fast run)
+
+---
+
+## D029: Dev container + Docker Compose despite single-user app scope
+
+**Date:** 2026-06 — **Status:** Accepted — **Issue:** [#162](https://github.com/zkarachiwala/TimeTracker/issues/162)
+
+**Context:** For a single-user timetracking app, a dev container and Docker Compose are objectively unnecessary. The app runs fine with a local SQL Server and `dotnet run`. The only person onboarding is the developer who built it. There is no "works on my machine" problem to solve.
+
+However, this project has two equally weighted goals: building a practical app and developing transferable skills. Dev containers and Docker Compose are industry-standard — they appear on every non-trivial professional .NET project. Understanding container networking, service dependencies, health checks, named volumes, and environment variable injection are skills that cannot be learned without hands-on use.
+
+**Decision:** Implement a VS Code dev container backed by Docker Compose (SQL Server + app services). This becomes the primary development environment, not a secondary option left unused. The implementation is documented as a reusable skill file (`~/.claude/skills/dotnet-devcontainer.md`) so the patterns transfer to future projects.
+
+This results in three SQL Server instances across the project lifecycle:
+- Local SQL Server — legacy local dev outside the container
+- Dev container SQL Server — primary dev environment going forward
+- Testcontainers SQL Server — container tests only (D028)
+
+**Alternatives considered:**
+- **Keep local-only dev:** Simpler, zero overhead, adequate for a personal app. Rejected because it offers no learning on industry-standard tooling.
+- **Use Codespaces as primary:** The `.devcontainer` spec works in Codespaces, but Google OAuth redirect URIs change per codespace instance and the free tier (120 core-hours/month) is likely insufficient for daily use. Local dev container avoids both constraints.
+
+**Consequences:**
+- ✅ Hands-on learning of Docker Compose, container networking, health checks, named volumes, and env var injection
+- ✅ The devcontainer spec doubles as Codespaces support for free — no extra work
+- ✅ Patterns extracted into a reusable skill file applicable to any future .NET project
+- ❌ Three SQL Server instances in a single-developer project — acknowledged overhead, justified by distinct educational purpose of each
+
+---
+
+## D030: HTTP-only inside the dev container
+
+**Date:** 2026-06 — **Status:** Accepted — **Issue:** [#162](https://github.com/zkarachiwala/TimeTracker/issues/162)
+
+**Context:** .NET dev certificates (`dotnet dev-certs https`) are machine-scoped and stored in the local certificate store. They do not exist inside a container, so HTTPS does not work out of the box. The alternatives are: run HTTP only, or generate and trust a certificate inside the container as part of `postCreateCommand`.
+
+**Decision:** Run HTTP only inside the dev container (`ASPNETCORE_URLS=http://+:5019`). Do not generate a dev certificate inside the container.
+
+The correct production mental model is: **containers expose HTTP, TLS terminates at the infrastructure edge** (load balancer, reverse proxy, CDN). This is how Azure App Service, Azure Container Apps, nginx, and virtually every production container deployment works. Teaching yourself HTTPS inside a container teaches a workaround for a dev environment quirk — not a transferable pattern.
+
+Google OAuth is not affected: Google explicitly whitelists `http://localhost` (any port) as a valid redirect URI for development. The `http://localhost:5019/signin-google` redirect URI must be registered in Google Cloud Console alongside the production HTTPS URI.
+
+**Alternatives considered:**
+- **Generate and trust a dev cert inside the container:** Possible, but involves exporting a `.pfx`, trusting it in the container OS, and configuring Kestrel to use it. This teaches a dev-only workaround and produces a false impression that containers normally handle TLS themselves.
+
+**Consequences:**
+- ✅ Teaches the production-correct pattern: HTTP inside containers, TLS at the edge
+- ✅ No certificate management in `postCreateCommand` — simpler, less to break
+- ✅ Google OAuth works without modification — `http://localhost` is whitelisted
+- ❌ App runs on HTTP inside the container — acceptable given this is a local dev environment on a trusted machine

--- a/docs/devcontainer-guide.md
+++ b/docs/devcontainer-guide.md
@@ -1,0 +1,208 @@
+# Dev Container Learning Guide
+
+This document explains the concepts behind the dev container setup in this project. Read it alongside the implementation in `.devcontainer/` and `docker-compose.yml`.
+
+---
+
+## What problem does a dev container solve?
+
+When multiple developers work on a project, "works on my machine" is a constant source of friction. One developer has .NET 8, another has .NET 10. One has SQL Server 2019, another has 2022. One is on Windows, another on macOS.
+
+A dev container packages the entire development environment — runtime, database, tools, extensions — into a Docker image. When you open the project in VS Code, it offers to reopen it inside the container. From that point on, everyone who opens the project gets the exact same environment, regardless of what's installed on their machine.
+
+For a single-developer project like this one, the benefit is different: **reproducibility and learning**. If you get a new machine, you open the project and it works. If you want to understand how real-world containerised development works, this is the pattern used across the industry.
+
+---
+
+## The two files that matter
+
+### `docker-compose.yml`
+
+Defines the *services* your application needs — in this case, the .NET app and SQL Server. Docker Compose manages starting them in the right order, connecting them on a shared network, and keeping data alive across restarts.
+
+### `.devcontainer/devcontainer.json`
+
+Tells VS Code (or GitHub Codespaces) how to use the Compose file as a development environment. It specifies:
+- Which service is your workspace (the one you edit code in)
+- Which ports to forward to your host machine
+- What to run after the container is created (`postCreateCommand`)
+- Which VS Code extensions to install automatically
+
+---
+
+## Container networking: why `db` not `localhost`
+
+This is the most common source of confusion when first learning Docker.
+
+When you run two services in Docker Compose, each gets its own network namespace — its own `localhost`. The app container's `localhost` is the app container. SQL Server's `localhost` is the SQL Server container. They cannot reach each other via `localhost`.
+
+Docker Compose creates a shared internal network and gives each service a DNS name matching its service name. So the app reaches SQL Server at `db` (the service name in `docker-compose.yml`), port 1433.
+
+```
+Your machine
+└── Docker network
+    ├── app container  (localhost = this container)
+    └── db container   (reachable as "db" from app container)
+```
+
+This is why the connection string inside the container is:
+```
+Server=db,1433;Database=...
+```
+Not `Server=localhost,1433`.
+
+---
+
+## Health checks: `service_healthy` vs `service_started`
+
+SQL Server takes 20–30 seconds to be ready to accept connections after the container starts. Without a health check, Docker Compose would mark it as started the moment the process launched — before it can actually handle queries.
+
+The `depends_on: condition: service_healthy` tells Docker Compose to wait until SQL Server passes its health check before starting the app container. The health check runs `sqlcmd -Q "SELECT 1"` — a trivial query that only succeeds when SQL Server is fully up.
+
+Without this, EF Core migrations in `postCreateCommand` would fail because SQL Server isn't ready yet.
+
+---
+
+## Named volumes: keeping your data
+
+```yaml
+volumes:
+  sqlserver_data:
+```
+
+A named volume is a persistent storage location managed by Docker. When you stop and restart containers (`docker compose down` then `docker compose up`), the data survives because it lives in the named volume, not inside the container itself.
+
+Compare this to what happens without a volume: every time you `docker compose down`, the SQL Server container is destroyed and all your data goes with it.
+
+**The one exception:** `docker compose down -v` destroys volumes too. Use this only when you want a completely clean slate.
+
+---
+
+## Environment variables replace User Secrets
+
+.NET User Secrets are stored in your user profile on your local machine (`~/.microsoft/usersecrets/`). They work for local development but don't travel into containers — the container has a different filesystem.
+
+Inside a container, environment variables fill the same role. ASP.NET Core reads them automatically and they take precedence over `appsettings.json`.
+
+ASP.NET Core uses `__` (double underscore) as the hierarchy separator in env var names:
+
+```yaml
+# This env var...
+ConnectionStrings__DefaultConnection: "Server=db,1433;..."
+
+# ...is equivalent to this in appsettings.json:
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=db,1433;..."
+  }
+}
+```
+
+The `.env` file (gitignored) feeds these values into Docker Compose without hardcoding secrets in `docker-compose.yml`.
+
+---
+
+## HTTP only inside the container
+
+The app runs on HTTP inside the container (`ASPNETCORE_URLS=http://+:5019`), not HTTPS.
+
+This is intentional and correct. In production, TLS is terminated at the infrastructure edge — a load balancer, reverse proxy, or CDN — and plain HTTP flows inside the infrastructure. The container never handles TLS directly.
+
+Running HTTPS inside a dev container is possible but requires generating and trusting a certificate inside the container. It teaches a workaround for a dev environment quirk, not the production pattern. HTTP inside the container *is* the production pattern.
+
+Your browser sees the app at `http://localhost:5019`. That's fine for local development.
+
+---
+
+## Google OAuth with HTTP
+
+Google OAuth has one explicit exception to its HTTPS requirement: `http://localhost` (any port). It is whitelisted for development use and will not trigger a security warning.
+
+You must register `http://localhost:5019/signin-google` as an authorized redirect URI in Google Cloud Console alongside the production HTTPS URI. See `docs/google-oauth-setup.md` for how to do this.
+
+This only applies to localhost. Never use HTTP on a real domain.
+
+---
+
+## `postCreateCommand`
+
+This runs once, inside your workspace container, after the dev container is first created. It's the equivalent of the setup steps a new developer would follow from a README.
+
+```json
+"postCreateCommand": "dotnet restore && dotnet ef database update --context TimeTrackerDataContext && dotnet ef database update --context IdentityDataContext"
+```
+
+What each step does:
+1. `dotnet restore` — downloads NuGet packages (the container may not have them cached)
+2. `dotnet ef database update` — applies all pending EF migrations to the containerised SQL Server
+
+This runs against `db` (the SQL Server container), not your local SQL Server.
+
+---
+
+## Common Docker Compose commands
+
+```bash
+# Start all services (detached — runs in background)
+docker compose up -d
+
+# Stop all services (data preserved in volumes)
+docker compose down
+
+# Stop and destroy volumes (complete clean slate)
+docker compose down -v
+
+# See running containers and their status
+docker compose ps
+
+# View logs from a specific service
+docker compose logs db
+docker compose logs app
+
+# Open a shell inside a running container
+docker compose exec app bash
+docker compose exec db bash
+
+# Rebuild the app image after a Dockerfile change
+docker compose up -d --build app
+```
+
+---
+
+## Codespaces: same spec, different host
+
+The `.devcontainer/devcontainer.json` works identically in GitHub Codespaces — that's the point of the dev container spec. VS Code (locally) and Codespaces both read the same file.
+
+The main differences when using Codespaces for this project:
+
+- **Ports** — Codespaces forwards ports automatically and gives you an HTTPS URL (e.g. `https://<codespace-name>-5019.app.github.dev`)
+- **Google OAuth** — that URL changes if you delete and recreate the codespace, requiring a new redirect URI registration in Google Cloud Console each time
+- **Free tier** — 120 core-hours/month on a personal account; SQL Server needs a 2-core machine, so ~60 hours/month before charges
+
+For occasional use, Codespaces is seamless. For daily development, the local dev container avoids the OAuth friction and free tier limits.
+
+---
+
+## The three SQL Server instances in this project
+
+This project ends up with three separate SQL Server instances, each serving a distinct purpose:
+
+| Instance | When it runs | Purpose |
+|----------|-------------|---------|
+| Local SQL Server | Always (existing setup) | Local development outside the container |
+| Dev container SQL Server | Inside the dev container | Isolated reproducible dev environment |
+| Testcontainers SQL Server | During container tests only | RLS and migration smoke tests |
+
+They never all run simultaneously in normal use. The fast unit tests (`Category!=Container`) use EF Core InMemory and touch no SQL Server at all.
+
+This is objectively more infrastructure than a single-user timetracking app needs. It exists because each instance teaches something different: containerised service dependencies (dev container), test isolation and Testcontainers patterns (#161), and the baseline of knowing how to run a database locally.
+
+---
+
+## Further reading
+
+- [VS Code Dev Containers documentation](https://code.visualstudio.com/docs/devcontainers/containers)
+- [Docker Compose reference](https://docs.docker.com/compose/compose-file/)
+- [Dev container spec (devcontainer.json)](https://containers.dev/implementors/json_reference/)
+- [GitHub Codespaces with dev containers](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration)
+- [ASP.NET Core configuration with environment variables](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/)


### PR DESCRIPTION
## Summary

- Adds VS Code dev container backed by Docker Compose (app + SQL Server)
- Uses official Microsoft devcontainer image with `docker-outside-of-docker` feature — Docker panel works inside VS Code
- Mounts WSL User Secrets read-only into the container — no credential duplication in `.env`
- `postCreateCommand` installs EF tools, restores packages, applies migrations on first build
- `postStartCommand` starts the app automatically on container start
- Adds `container` launch profile (`http://+:5019`) — correct binding for Docker port forwarding
- Adds `.vscode/tasks.json` (build, run, test tasks) and `launch.json` (F5 debug)
- Adds `docs/devcontainer-guide.md` — learning document covering concepts and gotchas
- Adds `~/.claude/skills/dotnet-devcontainer.md` — reusable skill for future .NET projects
- ADRs D029 (why we're doing this) and D030 (HTTP-only inside container) added to `docs/decisions.md`

## Why

Educational — dev containers and Docker Compose are industry-standard skills. Justified by the project's dual purpose (practical app + learning exercise). See D029.

## Gotchas documented

- `https`/`http` launch profiles bind to `localhost` — unreachable from outside container; use `container` profile
- User Secrets must be mounted from host — they don't exist inside the container by default
- Build artifacts (`obj/bin`) written by the container are owned by the container user; use Docker to clean them if switching between host and container builds
- `postStartCommand` vs `postCreateCommand` lifecycle explained in guide

## Test plan

- [ ] `docker compose up -d` starts both services cleanly
- [ ] VS Code "Reopen in Container" builds and attaches successfully
- [ ] `postCreateCommand` runs migrations against container SQL Server
- [ ] App starts automatically at `http://localhost:5019`
- [ ] Google OAuth works (User Secrets mounted correctly)
- [ ] Docker panel visible in VS Code sidebar
- [ ] Fast test suite passes: `dotnet test TimeTracker.Tests --filter "Category!=Container"`

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)