### PR TITLE
chore: update SESSION.md and devcontainer guide post-session

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,7 +1,22 @@
 # Session handoff — 2026-06-23
 
 ## Completed this session
-- ✅ **#161 Testcontainers for RLS and migration tests** — `SqlServerFixture` collection fixture starts one SQL Server container per session; `RlsIntegrationTests` rewritten (env var guards removed, runs in CI); `MigrationSmokeTests` added for both EF contexts; `[Trait("Category", "Container")]` filter keeps fast loop Docker-free. **Merged as PR #192.**
+- ✅ **#161 Testcontainers for RLS and migration tests** — merged as PR #192
+- ✅ **#162 Dev container and Docker Compose** — merged as PR #194
+
+## Dev container — how it works now
+- Open VS Code in the repo → click "Reopen in Container" from the `><` menu (bottom-left)
+- App starts automatically at `http://localhost:5019`
+- Google OAuth credentials come from WSL User Secrets (mounted read-only into the container)
+- Docker panel in VS Code sidebar manages containers (start, stop, logs)
+- To seed mock data: log in → POST `/api/dev/seed` via Swagger at `/swagger`
+- Data persists in named volume — only wiped by `docker compose down -v`
+
+## Known gotcha: build artifacts
+The container writes `obj/bin` files. Running tests from the host while the container is active fails with MSB3492 errors. Fix: stop the container first, or clean via Docker:
+```bash
+docker run --rm -v $(pwd):/workspace alpine sh -c "rm -rf /workspace/TimeTracker.*/obj /workspace/TimeTracker.*/bin"
+```
 
 ## Standard test commands
 **Before every PR:**
@@ -26,8 +41,8 @@ BROWSER= dotnet test TimeTracker.Playwright --filter "FullyQualifiedName~Showcas
 ### 🟡 Medium
 | # | Title |
 |---|-------|
-| ~~#161~~ | ~~Add Testcontainers for RLS and migration tests~~ ← **merged PR #192** |
-| #162 | Add dev container and Docker Compose for local development |
+| ~~#161~~ | ~~Add Testcontainers for RLS and migration tests~~ ← merged PR #192 |
+| ~~#162~~ | ~~Add dev container and Docker Compose~~ ← merged PR #194 |
 | #166 | CSV export for time entries |
 | #167 | Project budget tracking |
 | #121 | Add distributed tracing and APM via OpenTelemetry and Grafana Cloud |
@@ -64,4 +79,4 @@ cat SESSION.md
 ```
 
 ---
-*Updated 2026-06-23. Branch `feature/161-testcontainers-rls-migration` committed, PR not yet raised.*
+*Updated 2026-06-23. Both #161 and #162 merged. Next: #166 CSV export or #167 project budget tracking.*

--- a/docs/devcontainer-guide.md
+++ b/docs/devcontainer-guide.md
@@ -169,6 +169,35 @@ docker compose up -d --build app
 
 ---
 
+## Claude Code with a dev container
+
+When VS Code reopens inside the container, its integrated terminal runs inside the container too. Claude Code is not installed inside the container, so the VS Code extension won't work from there.
+
+**Recommended workflow (WSL2 on Windows):**
+- Keep a **Windows Terminal** tab open running WSL2 alongside VS Code
+- Run `claude` from there — it reads the same repo files via the shared WSL2 filesystem
+- VS Code (inside the container) handles editing, `dotnet run`, and EF migrations
+- Claude Code (host terminal) handles code review, file edits, and AI assistance
+
+The Docker extension (`ms-azuretools.vscode-docker`) works inside the container via the `docker-outside-of-docker` feature — so container management (restart, logs) works from within VS Code without needing a separate terminal.
+
+---
+
+## Common gotchas
+
+| Gotcha | Fix |
+|--------|-----|
+| SQL Server container exits immediately | Weak `SA_PASSWORD` — must meet complexity rules (upper, lower, digit, symbol, 8+ chars) |
+| App can't reach SQL Server | Use service name `db` in the connection string, not `localhost` |
+| `https` or `http` launch profile makes app unreachable | Use `container` profile — binds to `http://+:5019` (all interfaces), not `localhost` |
+| Google OAuth `ClientId` null / 500 on first request | User Secrets not mounted — check the volume mount in `docker-compose.yml` points to your WSL home |
+| Build artifacts conflict between host and container | Container writes `obj/bin` as its user; host can't overwrite them. Clean via: `docker run --rm -v $(pwd):/workspace alpine sh -c "rm -rf /workspace/TimeTracker.*/obj /workspace/TimeTracker.*/bin"` |
+| Data lost on `docker compose down` | Use named volume — only `docker compose down -v` destroys it |
+| Docker extension not working in VS Code | Ensure `docker-outside-of-docker` feature is in `devcontainer.json` and container was rebuilt |
+| VS Code doesn't offer "Reopen in Container" | Click the `><` icon bottom-left → "Reopen in Container" |
+
+---
+
 ## Codespaces: same spec, different host
 
 The `.devcontainer/devcontainer.json` works identically in GitHub Codespaces — that's the point of the dev container spec. VS Code (locally) and Codespaces both read the same file.


### PR DESCRIPTION
## Summary

- SESSION.md updated: marks #161 and #162 as merged, adds dev container workflow notes and build artifact gotcha
- `docs/devcontainer-guide.md` updated: adds Claude Code section, gotchas table, and Docker extension note — all discovered during the #162 implementation session

## No functional changes — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)