### PR TITLE
chore: upgrade dev container SQL Server from 2022 to 2025

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,12 @@ docker compose logs db        # SQL Server logs
 
 **Three SQL Server instances in this project** — they serve different purposes and never all run simultaneously:
 - Local SQL Server (existing) — local dev outside the container
-- Dev container SQL Server — inside the dev container (Docker)
+- Dev container SQL Server — SQL Server 2025 Developer edition inside the dev container (Docker)
 - Testcontainers SQL Server — spun up only during `Category=Container` tests
+
+**SQL Server 2025 features in use (dev container only):** native `json` data type, `vector` data type, `AI_GENERATE_EMBEDDINGS`, `AI_GENERATE_CHUNKS`, `sp_invoke_external_rest_endpoint`, `REGEXP_*` functions, `EDIT_DISTANCE*`/`JARO_WINKLER_*` fuzzy functions, vector indexes, and Data API Builder / SQL MCP Server. Several of these require `PREVIEW_FEATURES = ON` at the database level — see the DP-800 issues (#208–#223) for setup details per feature.
+
+**Ollama** is the local embedding and chat model provider. It runs on the Windows host; SQL Server 2025 reaches it via `host.docker.internal:11434`. Pull models before working on AI issues: `ollama pull nomic-embed-text` (embeddings) and `ollama pull llama3.2` (chat/RAG).
 
 ## Standard test commands
 

--- a/SESSION.md
+++ b/SESSION.md
@@ -1,8 +1,86 @@
-# Session handoff — 2026-06-23
+# Session handoff — 2026-06-27
 
 ## Completed this session
-- ✅ **#161 Testcontainers for RLS and migration tests** — merged as PR #192
-- ✅ **#162 Dev container and Docker Compose** — merged as PR #194
+- ✅ **#207 Upgrade dev container SQL Server 2022 → 2025** — PR open (branch `chore/upgrade-sqlserver-2025`)
+- ✅ Created 16 DP-800 exam learning issues (#208–#223) — all added to project board at Medium priority
+
+## DP-800 exam — learning issues (study guide order)
+
+Exam date: **6 August 2026**. All issues are fully local: SQL Server 2025 Developer + Ollama.
+
+### Design and develop database solutions (35–40%)
+
+#### Design and implement database objects
+| # | Title |
+|---|-------|
+| #208 | DP-800: Temporal table on TimeEntries (specialized tables) |
+| #209 | DP-800: Native JSON column and index on Projects (JSON columns) |
+
+#### Implement programmability objects
+| # | Title |
+|---|-------|
+| #210 | DP-800: TVF and stored procedure for time reporting (programmability objects) |
+
+#### Write advanced T-SQL
+| # | Title |
+|---|-------|
+| #211 | DP-800: CTEs and window functions for the reports page (advanced T-SQL) |
+| #212 | DP-800: JSON query functions on Projects metadata (JSON functions) |
+| #213 | DP-800: Regular expressions on time entry descriptions (regex functions) |
+| #214 | DP-800: Fuzzy matching for project and entry search (fuzzy string functions) |
+
+#### AI-assisted tools
+| # | Title |
+|---|-------|
+| #215 | DP-800: GitHub Copilot instruction file and SQL MCP Server (AI-assisted tools) |
+
+### Secure, optimize, and deploy database solutions (35–40%)
+
+#### Data security
+| # | Title |
+|---|-------|
+| #216 | DP-800: Dynamic Data Masking on TimeEntry descriptions (data security) |
+
+#### Performance optimization
+| # | Title |
+|---|-------|
+| #217 | DP-800: Query Store and DMV investigation (performance optimization) |
+
+#### CI/CD with SQL Database Projects
+| # | Title |
+|---|-------|
+| #218 | DP-800: SDK-style SQL Database Project with GitHub Actions CI (CI/CD) |
+
+#### Azure services integration
+| # | Title |
+|---|-------|
+| #219 | DP-800: Data API Builder REST and GraphQL endpoints (Azure services integration) |
+
+### Implement AI capabilities (25–30%)
+
+#### Models and embeddings
+| # | Title |
+|---|-------|
+| #220 | DP-800: External model and embeddings with Ollama (models and embeddings) |
+
+#### Intelligent search
+| # | Title |
+|---|-------|
+| #221 | DP-800: Full-text search on time entry descriptions (intelligent search) |
+| #222 | DP-800: Vector search and hybrid search with RRF (intelligent search) |
+
+#### RAG
+| # | Title |
+|---|-------|
+| #223 | DP-800: Natural language weekly summary via sp_invoke_external_rest_endpoint (RAG) |
+
+## Before starting any DP-800 issue
+1. `docker compose down -v` — wipe the 2022 volume
+2. Merge PR #207 (SQL Server 2025 upgrade) and pull main
+3. Reopen the dev container — `postCreateCommand` re-runs migrations
+4. For issues #213, #214, #222: `ALTER DATABASE SCOPED CONFIGURATION SET PREVIEW_FEATURES = ON`
+5. For issue #223: `EXEC sp_configure 'external rest endpoint enabled', 1; RECONFIGURE;`
+6. Ollama models: `ollama pull nomic-embed-text` (#220, #222) and `ollama pull llama3.2` (#223)
 
 ## Dev container — how it works now
 - Open VS Code in the repo → click "Reopen in Container" from the `><` menu (bottom-left)
@@ -36,13 +114,11 @@ dotnet test TimeTracker.Tests --filter "Category=Container"
 BROWSER= dotnet test TimeTracker.Playwright --filter "FullyQualifiedName~ShowcaseTests" --logger "console;verbosity=normal" --blame-hang-timeout 60s
 ```
 
-## Backlog (from GitHub project board)
+## Backlog (non-DP-800)
 
 ### 🟡 Medium
 | # | Title |
 |---|-------|
-| ~~#161~~ | ~~Add Testcontainers for RLS and migration tests~~ ← merged PR #192 |
-| ~~#162~~ | ~~Add dev container and Docker Compose~~ ← merged PR #194 |
 | #166 | CSV export for time entries |
 | #167 | Project budget tracking |
 | #121 | Add distributed tracing and APM via OpenTelemetry and Grafana Cloud |
@@ -79,4 +155,4 @@ cat SESSION.md
 ```
 
 ---
-*Updated 2026-06-23. Both #161 and #162 merged. Next: #166 CSV export or #167 project budget tracking.*
+*Updated 2026-06-27. SQL Server 2025 upgrade PR open (#207). 16 DP-800 learning issues created (#208–#223). Next: merge #207, then start DP-800 issues in study guide order from #208.*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mcr.microsoft.com/mssql/server:2022-latest
+    image: mcr.microsoft.com/mssql/server:2025-latest
     environment:
       ACCEPT_EULA: "Y"
       SA_PASSWORD: "${SA_PASSWORD}"

--- a/docs/devcontainer-guide.md
+++ b/docs/devcontainer-guide.md
@@ -6,7 +6,7 @@ This document explains the concepts behind the dev container setup in this proje
 
 ## What problem does a dev container solve?
 
-When multiple developers work on a project, "works on my machine" is a constant source of friction. One developer has .NET 8, another has .NET 10. One has SQL Server 2019, another has 2022. One is on Windows, another on macOS.
+When multiple developers work on a project, "works on my machine" is a constant source of friction. One developer has .NET 8, another has .NET 10. One has SQL Server 2022, another has 2025. One is on Windows, another on macOS.
 
 A dev container packages the entire development environment — runtime, database, tools, extensions — into a Docker image. When you open the project in VS Code, it offers to reopen it inside the container. From that point on, everyone who opens the project gets the exact same environment, regardless of what's installed on their machine.
 


### PR DESCRIPTION
## Summary
- Updates `docker-compose.yml` image tag to `mcr.microsoft.com/mssql/server:2025-latest`
- Healthcheck path unchanged (`/opt/mssql-tools18/bin/sqlcmd`)
- Updates `CLAUDE.md` with SQL Server 2025 feature notes, Ollama setup for AI issues
- Updates `docs/devcontainer-guide.md` version reference
- Updates `SESSION.md` with DP-800 learning backlog (#208–#223)

## Before rebuilding the container
The `sqlserver_data` volume must be wiped — SQL Server cannot open 2022 data files:
```bash
docker compose down -v
```
Then reopen in the dev container — `postCreateCommand` re-runs EF migrations.

## Test plan
- [ ] `docker compose down -v` then reopen dev container
- [ ] Confirm app starts at `http://localhost:5019`
- [ ] Confirm `SELECT @@VERSION` returns SQL Server 2025 in SSMS

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)