### PR TITLE
chore: trim SESSION.md to app-only content

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,133 +1,8 @@
-# Session handoff — 2026-06-27
+# Session handoff — 2026-06-28
 
-## Completed this session
-- ✅ **#207 Upgrade dev container SQL Server 2022 → 2025** — merged
-- ✅ Created 16 DP-800 exam learning issues (#208–#223) — all added to project board at Medium priority
-- ✅ Created 16 additional DP-800 gap issues (#258–#273) from Udemy course map — all added to project board
-  - #258: SEQUENCE objects (section 5)
-  - #259: Views and Instead-of triggers (section 6)
-  - #260: Correlated subqueries and recursive CTEs (section 7)
-  - #261: Error handling and scalar functions (section 8)
-  - #262: Graph tables with MATCH (section 12)
-  - #263: Indexes, SARGable queries, execution plans (section 13)
-  - #264: Table partitioning on TimeEntries (section 13)
-  - #265: Columnstore indexes (section 13)
-  - #266: In-memory, external, and ledger tables (section 14)
-  - #267: Data encryption, permissions, and RLS (section 17)
-  - #268: SQL Server auditing (section 17)
-  - #269: Locking, blocking, isolation levels (section 18)
-  - #270: Unit testing and reference data in SQL Projects (section 19)
-  - #271: Azure Monitor metric alerts for SQL (section 21)
-  - #272: CDC, Change Tracking, and CES (section 26)
-  - #273: Azure Functions and Logic Apps with SQL (section 26)
-- ✅ Created `~/dp800-course-map.md` (outside source control) mapping all 170 Udemy lectures to issues
-- ✅ Created AZ-400 GitHub label
-- ✅ Created 27 AZ-400 exam learning issues (#225–#251) — all added to project board at Medium priority
-  - #225: Budget alert (tagged DP-800 + AZ-400 — do this first before incurring any Azure costs)
-  - #226–#229: Processes & communications (wiki, release notes, Teams webhook, DORA metrics)
-  - #230–#232: Source control (branch protection, SemVer, git recovery)
-  - #233–#245: Build & release pipelines (packages, coverage, load test, environments, templates, runner, feature flags, migrations, blue-green, Bicep, ADE, pipeline health, retention)
-  - #246–#249: Security & compliance (OIDC, Key Vault, CodeQL, Managed Identity)
-  - #250–#251: Instrumentation (App Insights, KQL)
-- ✅ Created Azure DevOps label and 5 Azure DevOps issues (#252–#256) — all tagged AZ-400 + Azure DevOps
-  - #252: Azure Pipelines YAML CI (parallel to GitHub Actions)
-  - #253: Azure Boards — work items, sprints, AB# commit linking
-  - #254: Azure Repos — branch policies, build validation
-  - #255: Azure Artifacts — NuGet feed with upstream sources
-  - #256: Azure Pipelines environments, approvals, deployment jobs
-- ✅ Reformatted all 27 AZ-400 issues (#225–#251) to match DP-800 format (blockquote exam objective, Your task, Explore with hands-on commands, Exam checkpoint)
-
-## DP-800 exam — learning issues (study guide order)
-
-All issues are fully local: SQL Server 2025 Developer + Ollama.
-
-### Design and develop database solutions (35–40%)
-
-#### Design and implement database objects
-| # | Title |
-|---|-------|
-| #208 | DP-800: Temporal table on TimeEntries (specialized tables) |
-| #209 | DP-800: Native JSON column and index on Projects (JSON columns) |
-
-#### Implement programmability objects
-| # | Title |
-|---|-------|
-| #210 | DP-800: TVF and stored procedure for time reporting (programmability objects) |
-
-#### Write advanced T-SQL
-| # | Title |
-|---|-------|
-| #211 | DP-800: CTEs and window functions for the reports page (advanced T-SQL) |
-| #212 | DP-800: JSON query functions on Projects metadata (JSON functions) |
-| #213 | DP-800: Regular expressions on time entry descriptions (regex functions) |
-| #214 | DP-800: Fuzzy matching for project and entry search (fuzzy string functions) |
-
-#### AI-assisted tools
-| # | Title |
-|---|-------|
-| #215 | DP-800: GitHub Copilot instruction file and SQL MCP Server (AI-assisted tools) |
-
-### Secure, optimize, and deploy database solutions (35–40%)
-
-#### Data security
-| # | Title |
-|---|-------|
-| #216 | DP-800: Dynamic Data Masking on TimeEntry descriptions (data security) |
-
-#### Performance optimization
-| # | Title |
-|---|-------|
-| #217 | DP-800: Query Store and DMV investigation (performance optimization) |
-
-#### CI/CD with SQL Database Projects
-| # | Title |
-|---|-------|
-| #218 | DP-800: SDK-style SQL Database Project with GitHub Actions CI (CI/CD) |
-
-#### Azure services integration
-| # | Title |
-|---|-------|
-| #219 | DP-800: Data API Builder REST and GraphQL endpoints (Azure services integration) |
-
-### Implement AI capabilities (25–30%)
-
-#### Models and embeddings
-| # | Title |
-|---|-------|
-| #220 | DP-800: External model and embeddings with Ollama (models and embeddings) |
-
-#### Intelligent search
-| # | Title |
-|---|-------|
-| #221 | DP-800: Full-text search on time entry descriptions (intelligent search) |
-| #222 | DP-800: Vector search and hybrid search with RRF (intelligent search) |
-
-#### RAG
-| # | Title |
-|---|-------|
-| #223 | DP-800: Natural language weekly summary via sp_invoke_external_rest_endpoint (RAG) |
-
-## Before starting any DP-800 issue
-1. `docker compose down -v` — wipe the 2022 volume
-2. Merge PR #207 (SQL Server 2025 upgrade) and pull main
-3. Reopen the dev container — `postCreateCommand` re-runs migrations
-4. For issues #213, #214, #222: `ALTER DATABASE SCOPED CONFIGURATION SET PREVIEW_FEATURES = ON`
-5. For issue #223: `EXEC sp_configure 'external rest endpoint enabled', 1; RECONFIGURE;`
-6. Ollama models: `ollama pull nomic-embed-text` (#220, #222) and `ollama pull llama3.2` (#223)
-
-## Dev container — how it works now
-- Open VS Code in the repo → click "Reopen in Container" from the `><` menu (bottom-left)
-- App starts automatically at `http://localhost:5019`
-- Google OAuth credentials come from WSL User Secrets (mounted read-only into the container)
-- Docker panel in VS Code sidebar manages containers (start, stop, logs)
-- To seed mock data: log in → POST `/api/dev/seed` via Swagger at `/swagger`
-- Data persists in named volume — only wiped by `docker compose down -v`
-
-## Known gotcha: build artifacts
-The container writes `obj/bin` files. Running tests from the host while the container is active fails with MSB3492 errors. Fix: stop the container first, or clean via Docker:
-```bash
-docker run --rm -v $(pwd):/workspace alpine sh -c "rm -rf /workspace/TimeTracker.*/obj /workspace/TimeTracker.*/bin"
-```
+## Cert study
+All DP-800 and AZ-400 learning issues have moved to the study-plans repo.
+5 schema-change issues remain here: #208, #209, #258, #263, #267 — see study-plans SESSION.md for details.
 
 ## Standard test commands
 **Before every PR:**
@@ -147,7 +22,19 @@ dotnet test TimeTracker.Tests --filter "Category=Container"
 BROWSER= dotnet test TimeTracker.Playwright --filter "FullyQualifiedName~ShowcaseTests" --logger "console;verbosity=normal" --blame-hang-timeout 60s
 ```
 
-## Backlog (non-DP-800)
+## Dev container
+- Open VS Code → "Reopen in Container"
+- App starts automatically at `http://localhost:5019`
+- Google OAuth credentials come from WSL User Secrets (mounted read-only into the container)
+- To seed mock data: log in → POST `/api/dev/seed` via Swagger at `/swagger`
+- Data persists in named volume — only wiped by `docker compose down -v`
+
+**Known gotcha:** Container writes `obj/bin` files. Running tests from host while container is active fails with MSB3492. Fix: stop container first, or:
+```bash
+docker run --rm -v $(pwd):/workspace alpine sh -c "rm -rf /workspace/TimeTracker.*/obj /workspace/TimeTracker.*/bin"
+```
+
+## App backlog
 
 ### 🟡 Medium
 | # | Title |
@@ -164,7 +51,6 @@ BROWSER= dotnet test TimeTracker.Playwright --filter "FullyQualifiedName~Showcas
 | #170 | Time rounding rules |
 | #36  | Invoice export — uninvoiced entries per client for Zoho Books |
 | #108 | Run Lighthouse audit and address findings |
-| #163 | Define Azure infrastructure as code with Bicep |
 | #102 | Add email/password login fallback and TOTP MFA |
 | #96  | Add staging environment (requires paid tier upgrade) |
 
@@ -186,40 +72,3 @@ cd /home/zkarachiwala/repos/TimeTracker
 git status
 cat SESSION.md
 ```
-
-## AZ-400 exam — learning issues (study guide order)
-
-All issues follow the learning exercise format: read-first links, YOUR task (you do the work), how to verify, and exam checkpoint questions.
-
-| # | Title | Skill area |
-|---|-------|-----------|
-| #225 | Budget alert (DP-800 + AZ-400) | Prerequisite — do first |
-| #226 | Mermaid architecture diagrams in wiki | Processes & comms |
-| #227 | Automated release notes from git history | Processes & comms |
-| #228 | GitHub → Teams webhook for CI/deploy events | Processes & comms |
-| #229 | DORA metrics dashboard | Processes & comms |
-| #230 | Branch protection rules and CODEOWNERS | Source control |
-| #231 | SemVer tagging strategy and automated version bump | Source control |
-| #232 | Git data recovery (reflog, bisect, revert, filter-repo) | Source control |
-| #233 | Publish TimeTracker.Contracts to GitHub Packages | Pipelines |
-| #234 | Code coverage with Coverlet and CI quality gate | Pipelines |
-| #235 | k6 load test in CI pipeline | Pipelines |
-| #236 | Multi-stage pipeline with GitHub Environments + approval gates | Pipelines |
-| #237 | Reusable YAML workflow templates | Pipelines |
-| #238 | Self-hosted GitHub Actions runner in Docker | Pipelines |
-| #239 | Feature flags with Azure App Configuration | Pipelines |
-| #240 | EF Core migrations as explicit pipeline step | Pipelines |
-| #241 | Blue-green deployment docs + feature flag simulation | Pipelines |
-| #242 | Bicep templates for full Azure infrastructure | Pipelines / IaC |
-| #243 | Azure Deployment Environments for PR environments | Pipelines / IaC |
-| #244 | Pipeline health (failure rate, flaky tests) | Pipelines |
-| #245 | Pipeline artifact retention policy | Pipelines |
-| #246 | OIDC workload identity federation (replace PAT) | Security |
-| #247 | Azure Key Vault for secrets | Security |
-| #248 | CodeQL and GitHub Advanced Security | Security |
-| #249 | Managed Identity for App Service → Azure SQL | Security |
-| #250 | Application Insights instrumentation | Instrumentation |
-| #251 | KQL queries for operational metrics | Instrumentation |
-
----
-*Updated 2026-06-27. SQL Server 2025 upgrade merged (#207). 32 DP-800 learning issues (#208–#223, #258–#273) + 27 AZ-400 issues (#225–#251) + 5 Azure DevOps issues (#252–#256) created. Full Udemy course mapped to issues in `~/dp800-course-map.md`. Next: start DP-800 from #208 working sequentially through the course. For AZ-400, start with #225 (budget alert) before incurring any Azure costs.*


### PR DESCRIPTION
## Summary
- Cert study sections (DP-800, AZ-400 issue lists, course progress) moved to `study-plans` repo SESSION.md
- TimeTracker SESSION.md now covers app backlog, tech debt, test commands, and dev container notes only
- References study-plans for the 5 schema-change issues that remain in this repo (#208, #209, #258, #263, #267)

## Why
Learning issues have been closed and moved to a dedicated `study-plans` repo to keep TimeTracker focused on app work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)