### PR TITLE
feat: PROJ/CLI ref codes via SQL SEQUENCE and computed columns

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:latest": {
+      "version": "1.10.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e",
+      "integrity": "sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,11 +9,15 @@
   "mounts": [
     "source=${localEnv:HOME}/.microsoft/usersecrets,target=/home/vscode/.microsoft/usersecrets,type=bind,consistency=cached,readonly"
   ],
-  "forwardPorts": [5019],
+  "forwardPorts": [5019, 1434],
   "portsAttributes": {
     "5019": {
       "label": "TimeTracker App",
       "onAutoForward": "notify"
+    },
+    "1434": {
+      "label": "SQL Server (dev container)",
+      "onAutoForward": "silent"
     }
   },
   "postCreateCommand": "dotnet tool install --global dotnet-ef && dotnet restore TimeTracker.sln && dotnet ef database update --project TimeTracker.Web --context TimeTrackerDataContext && dotnet ef database update --project TimeTracker.Web --context IdentityDataContext",

--- a/TimeTracker.Client/Features/Clients/Components/ClientSheet.razor
+++ b/TimeTracker.Client/Features/Clients/Components/ClientSheet.razor
@@ -10,7 +10,13 @@
     <div class="sheet-grip-pill"></div>
 
     <MudDrawerHeader Class="d-flex align-center justify-space-between pa-4">
-        <MudText Typo="Typo.h6">@(IsEditing ? "Edit client" : "New client")</MudText>
+        <div>
+            <MudText Typo="Typo.h6">@(IsEditing ? "Edit client" : "New client")</MudText>
+            @if (IsEditing && !string.IsNullOrEmpty(Client?.RefCode))
+            {
+                <MudText Typo="Typo.caption" Style="color:var(--mud-palette-text-disabled)">@Client.RefCode</MudText>
+            }
+        </div>
         <MudIconButton Icon="@Icons.Material.Filled.Close" OnClick="Close" />
     </MudDrawerHeader>
 

--- a/TimeTracker.Client/Features/Clients/Pages/ClientDetailPage.razor
+++ b/TimeTracker.Client/Features/Clients/Pages/ClientDetailPage.razor
@@ -22,7 +22,13 @@
                 @client.Name[..Math.Min(2, client.Name.Length)].ToUpper()
             </MudAvatar>
             <div class="flex-1" style="min-width:0">
-                <MudText Typo="Typo.h6" Style="line-height:1.2">@client.Name</MudText>
+                <div class="d-flex align-baseline gap-2">
+                    <MudText Typo="Typo.h6" Style="line-height:1.2">@client.Name</MudText>
+                    @if (!string.IsNullOrEmpty(client.RefCode))
+                    {
+                        <MudText Typo="Typo.caption" Style="color:var(--mud-palette-text-disabled)">@client.RefCode</MudText>
+                    }
+                </div>
                 @if (client.IsArchived)
                 {
                     <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Style="height:20px; font-size:.7rem">archived</MudChip>

--- a/TimeTracker.Client/Features/Clients/Pages/ClientsPage.razor
+++ b/TimeTracker.Client/Features/Clients/Pages/ClientsPage.razor
@@ -23,7 +23,13 @@
                             @c.Name[..Math.Min(2, c.Name.Length)].ToUpper()
                         </MudAvatar>
                         <div class="flex-1" style="min-width:0">
-                            <MudText Typo="Typo.body1" Style="font-weight:500; line-height:1.3">@c.Name</MudText>
+                            <div class="d-flex align-baseline gap-2">
+                                <MudText Typo="Typo.body1" Style="font-weight:500; line-height:1.3">@c.Name</MudText>
+                                @if (!string.IsNullOrEmpty(c.RefCode))
+                                {
+                                    <MudText Typo="Typo.caption" Style="color:var(--mud-palette-text-disabled)">@c.RefCode</MudText>
+                                }
+                            </div>
                             <div class="d-flex align-center gap-2 mt-1 flex-wrap">
                                 @if (!string.IsNullOrEmpty(c.ContactName))
                                 {

--- a/TimeTracker.Client/Features/Projects/Components/ProjectCard.razor
+++ b/TimeTracker.Client/Features/Projects/Components/ProjectCard.razor
@@ -8,7 +8,13 @@
                 @Initials
             </MudAvatar>
             <div class="flex-1" style="min-width:0">
-                <MudText Typo="Typo.body1" Style="font-weight:500; line-height:1.3">@Project.Name</MudText>
+                <div class="d-flex align-baseline gap-2">
+                    <MudText Typo="Typo.body1" Style="font-weight:500; line-height:1.3">@Project.Name</MudText>
+                    @if (!string.IsNullOrEmpty(Project.RefCode))
+                    {
+                        <MudText Typo="Typo.caption" Style="color:var(--mud-palette-text-disabled)">@Project.RefCode</MudText>
+                    }
+                </div>
                 <div class="d-flex align-center gap-2 mt-1 flex-wrap">
                     <MudText Typo="Typo.caption">@(Project.ClientName ?? "No client")</MudText>
                     @if (Project.HourlyRate is > 0)

--- a/TimeTracker.Client/Features/Projects/Components/ProjectSheet.razor
+++ b/TimeTracker.Client/Features/Projects/Components/ProjectSheet.razor
@@ -10,7 +10,13 @@
     <div class="sheet-grip-pill"></div>
 
     <MudDrawerHeader Class="d-flex align-center justify-space-between pa-4">
-        <MudText Typo="Typo.h6">@(IsEditing ? "Edit project" : "New project")</MudText>
+        <div>
+            <MudText Typo="Typo.h6">@(IsEditing ? "Edit project" : "New project")</MudText>
+            @if (IsEditing && !string.IsNullOrEmpty(Project?.RefCode))
+            {
+                <MudText Typo="Typo.caption" Style="color:var(--mud-palette-text-disabled)">@Project.RefCode</MudText>
+            }
+        </div>
         <MudIconButton Icon="@Icons.Material.Filled.Close" OnClick="Close" />
     </MudDrawerHeader>
 

--- a/TimeTracker.Client/Features/Projects/Pages/ProjectDetailPage.razor
+++ b/TimeTracker.Client/Features/Projects/Pages/ProjectDetailPage.razor
@@ -25,7 +25,13 @@
                 @Initials
             </MudAvatar>
             <div class="flex-1" style="min-width:0">
-                <MudText Typo="Typo.h6" Style="line-height:1.2">@project.Name</MudText>
+                <div class="d-flex align-baseline gap-2">
+                    <MudText Typo="Typo.h6" Style="line-height:1.2">@project.Name</MudText>
+                    @if (!string.IsNullOrEmpty(project.RefCode))
+                    {
+                        <MudText Typo="Typo.caption" Style="color:var(--mud-palette-text-disabled)">@project.RefCode</MudText>
+                    }
+                </div>
                 <MudText Typo="Typo.caption">@(project.ClientName ?? "No client")</MudText>
             </div>
         </div>

--- a/TimeTracker.Contracts/Features/Clients/ClientModels.cs
+++ b/TimeTracker.Contracts/Features/Clients/ClientModels.cs
@@ -10,7 +10,8 @@ public record ClientResponse(
     decimal? AwardRate,
     string? ContactName,
     string? ContactEmail,
-    string? ContactPhone
+    string? ContactPhone,
+    string RefCode = ""
 );
 
 public class ClientRequest

--- a/TimeTracker.Contracts/Features/Projects/ProjectModels.cs
+++ b/TimeTracker.Contracts/Features/Projects/ProjectModels.cs
@@ -10,7 +10,8 @@ public record ProjectResponse(
     decimal? HourlyRate,
     string? Description,
     DateTime? StartDate,
-    DateTime? EndDate
+    DateTime? EndDate,
+    string RefCode = ""
 );
 
 public class ProjectRequest

--- a/TimeTracker.Shared/Entities/Client.cs
+++ b/TimeTracker.Shared/Entities/Client.cs
@@ -10,4 +10,6 @@ public class Client : SoftDeleteableEntity
     public string? ContactEmail { get; set; }
     public string? ContactPhone { get; set; }
     public List<Project> Projects { get; set; } = [];
+    public int ClientSeqId { get; set; }
+    public string RefCode { get; set; } = string.Empty;
 }

--- a/TimeTracker.Shared/Entities/Project.cs
+++ b/TimeTracker.Shared/Entities/Project.cs
@@ -11,4 +11,6 @@ public class Project : SoftDeleteableEntity
     public DateTime? EndDate { get; set; }
     public List<TimeEntry>? TimeEntries { get; set; } = [];
     public List<ProjectUser> ProjectUsers { get; set; } = [];
+    public int ProjectSeqId { get; set; }
+    public string RefCode { get; set; } = string.Empty;
 }

--- a/TimeTracker.Tests/Features/Clients/ClientServiceTests.cs
+++ b/TimeTracker.Tests/Features/Clients/ClientServiceTests.cs
@@ -197,6 +197,33 @@ public class ClientServiceTests
     }
 
     [Fact]
+    public async Task CreateClient_DoesNotSetRefCode()
+    {
+        var options = CreateOptions();
+
+        await CreateService(options).CreateClient(new ClientCreateRequest { Name = "New Client" });
+
+        using var context = new TimeTrackerDataContext(options);
+        Assert.Equal(string.Empty, context.Clients.Single().RefCode);
+    }
+
+    [Fact]
+    public async Task UpdateClient_DoesNotModifyRefCode()
+    {
+        var options = CreateOptions();
+        using var seed = new TimeTrackerDataContext(options);
+        var client = MakeClient("Acme");
+        client.RefCode = "CLI-001";
+        seed.Clients.Add(client);
+        await seed.SaveChangesAsync();
+
+        await CreateService(options).UpdateClient(client.Id, new ClientUpdateRequest { Name = "Acme Updated", DefaultHourlyRate = 200m });
+
+        using var context = new TimeTrackerDataContext(options);
+        Assert.Equal("CLI-001", context.Clients.Single().RefCode);
+    }
+
+    [Fact]
     public async Task ArchiveClient_SetsIsArchived()
     {
         var options = CreateOptions();

--- a/TimeTracker.Tests/Features/Projects/ProjectServiceTests.cs
+++ b/TimeTracker.Tests/Features/Projects/ProjectServiceTests.cs
@@ -314,6 +314,33 @@ public class ProjectServiceTests
             CreateService(options).UpdateProject(999, new ProjectUpdateRequest { Name = "Updated" }));
     }
 
+    [Fact]
+    public async Task CreateProject_DoesNotSetRefCode()
+    {
+        var options = CreateOptions();
+
+        await CreateService(options).CreateProject(new ProjectCreateRequest { Name = "New Project" });
+
+        using var context = new TimeTrackerDataContext(options);
+        Assert.Equal(string.Empty, context.Projects.Single().RefCode);
+    }
+
+    [Fact]
+    public async Task UpdateProject_DoesNotModifyRefCode()
+    {
+        var options = CreateOptions();
+        using var seed = new TimeTrackerDataContext(options);
+        var project = MakeProject(UserId);
+        project.RefCode = "PROJ-001";
+        seed.Projects.Add(project);
+        await seed.SaveChangesAsync();
+
+        await CreateService(options).UpdateProject(project.Id, new ProjectUpdateRequest { Name = "Updated Name", HourlyRate = 200m });
+
+        using var context = new TimeTrackerDataContext(options);
+        Assert.Equal("PROJ-001", context.Projects.Single().RefCode);
+    }
+
     // --- GetDeletedProjects / RestoreProject ---
 
     [Fact]

--- a/TimeTracker.Web/Data/TimeTrackerDataContext.cs
+++ b/TimeTracker.Web/Data/TimeTrackerDataContext.cs
@@ -25,6 +25,29 @@ public class TimeTrackerDataContext : DbContext
         modelBuilder.Entity<TimeTracker.Shared.Entities.Client>().Property(c => c.DefaultHourlyRate).HasPrecision(18, 2);
         modelBuilder.Entity<TimeTracker.Shared.Entities.Client>().Property(c => c.AwardRate).HasPrecision(18, 2);
         modelBuilder.Entity<Project>().Property(p => p.HourlyRate).HasPrecision(18, 2);
+
+        // Sequence numbering
+
+        modelBuilder.HasSequence<int>("seq_ProjectRef", schema: "app")
+            .StartsAt(1).IncrementsBy(1);
+
+        modelBuilder.Entity<Project>().Property(p => p.ProjectSeqId)
+            .HasDefaultValueSql("NEXT VALUE FOR app.seq_ProjectRef");
+
+        modelBuilder.Entity<Project>().Property(p => p.RefCode)
+            .HasComputedColumnSql("'PROJ-' + RIGHT('000' + CAST(ProjectSeqId AS VARCHAR(10)), 3)", stored: true)
+            .HasMaxLength(20);
+
+        modelBuilder.HasSequence<int>("seq_ClientRef", schema: "app")
+            .StartsAt(1).IncrementsBy(1);
+
+        modelBuilder.Entity<TimeTracker.Shared.Entities.Client>().Property(c => c.ClientSeqId)
+            .HasDefaultValueSql("NEXT VALUE FOR app.seq_ClientRef");
+            
+        modelBuilder.Entity<TimeTracker.Shared.Entities.Client>().Property(c => c.RefCode)
+            .HasComputedColumnSql("'CLI-' + RIGHT('000' + CAST(ClientSeqId AS VARCHAR(10)), 3)", stored: true)
+            .HasMaxLength(20);
+
         base.OnModelCreating(modelBuilder);
     }
 

--- a/TimeTracker.Web/Migrations/20260628003821_AddRefCodes.Designer.cs
+++ b/TimeTracker.Web/Migrations/20260628003821_AddRefCodes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TimeTracker.Web.Data;
 
@@ -11,9 +12,11 @@ using TimeTracker.Web.Data;
 namespace TimeTracker.Web.Migrations
 {
     [DbContext(typeof(TimeTrackerDataContext))]
-    partial class TimeTrackerDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260628003821_AddRefCodes")]
+    partial class AddRefCodes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TimeTracker.Web/Migrations/20260628003821_AddRefCodes.cs
+++ b/TimeTracker.Web/Migrations/20260628003821_AddRefCodes.cs
@@ -1,0 +1,90 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TimeTracker.Web.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRefCodes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateSequence<int>(
+                name: "seq_ClientRef",
+                schema: "app");
+
+            migrationBuilder.CreateSequence<int>(
+                name: "seq_ProjectRef",
+                schema: "app");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ProjectSeqId",
+                schema: "app",
+                table: "Projects",
+                type: "int",
+                nullable: false,
+                defaultValueSql: "NEXT VALUE FOR app.seq_ProjectRef");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ClientSeqId",
+                schema: "app",
+                table: "Clients",
+                type: "int",
+                nullable: false,
+                defaultValueSql: "NEXT VALUE FOR app.seq_ClientRef");
+
+            migrationBuilder.AddColumn<string>(
+                name: "RefCode",
+                schema: "app",
+                table: "Projects",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: false,
+                computedColumnSql: "'PROJ-' + RIGHT('000' + CAST(ProjectSeqId AS VARCHAR(10)), 3)",
+                stored: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RefCode",
+                schema: "app",
+                table: "Clients",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: false,
+                computedColumnSql: "'CLI-' + RIGHT('000' + CAST(ClientSeqId AS VARCHAR(10)), 3)",
+                stored: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RefCode",
+                schema: "app",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "RefCode",
+                schema: "app",
+                table: "Clients");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectSeqId",
+                schema: "app",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "ClientSeqId",
+                schema: "app",
+                table: "Clients");
+
+            migrationBuilder.DropSequence(
+                name: "seq_ClientRef",
+                schema: "app");
+
+            migrationBuilder.DropSequence(
+                name: "seq_ProjectRef",
+                schema: "app");
+        }
+    }
+}

--- a/TimeTracker.Web/Migrations/20260628064918_ExemptDbOwnerFromRls.Designer.cs
+++ b/TimeTracker.Web/Migrations/20260628064918_ExemptDbOwnerFromRls.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TimeTracker.Web.Data;
 
@@ -11,9 +12,11 @@ using TimeTracker.Web.Data;
 namespace TimeTracker.Web.Migrations
 {
     [DbContext(typeof(TimeTrackerDataContext))]
-    partial class TimeTrackerDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260628064918_ExemptDbOwnerFromRls")]
+    partial class ExemptDbOwnerFromRls
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TimeTracker.Web/Migrations/20260628064918_ExemptDbOwnerFromRls.cs
+++ b/TimeTracker.Web/Migrations/20260628064918_ExemptDbOwnerFromRls.cs
@@ -1,0 +1,114 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TimeTracker.Web.Migrations
+{
+    /// <inheritdoc />
+    public partial class ExemptDbOwnerFromRls : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Drop policies before dropping the functions they reference
+            migrationBuilder.Sql("DROP SECURITY POLICY IF EXISTS app.ProjectsUserPolicy;");
+            migrationBuilder.Sql("DROP SECURITY POLICY IF EXISTS app.ProjectUsersUserPolicy;");
+            migrationBuilder.Sql("DROP SECURITY POLICY IF EXISTS app.TimeEntriesUserPolicy;");
+            migrationBuilder.Sql("DROP FUNCTION IF EXISTS app.fn_filter_projects_by_user;");
+            migrationBuilder.Sql("DROP FUNCTION IF EXISTS app.fn_filter_by_user_id;");
+
+            // Recreate with db_owner exemption so SA can query app tables without setting session context
+            migrationBuilder.Sql("""
+                CREATE FUNCTION app.fn_filter_by_user_id(@UserId nvarchar(450))
+                RETURNS TABLE
+                WITH SCHEMABINDING
+                AS
+                RETURN SELECT 1 AS fn_result
+                WHERE @UserId = CAST(SESSION_CONTEXT(N'UserId') AS nvarchar(450))
+                   OR IS_MEMBER('db_owner') = 1;
+                """);
+
+            migrationBuilder.Sql("""
+                CREATE FUNCTION app.fn_filter_projects_by_user(@ProjectId int)
+                RETURNS TABLE
+                WITH SCHEMABINDING
+                AS
+                RETURN SELECT 1 AS fn_result
+                WHERE EXISTS (
+                    SELECT 1 FROM app.ProjectUsers
+                    WHERE ProjectId = @ProjectId
+                    AND UserId = CAST(SESSION_CONTEXT(N'UserId') AS nvarchar(450))
+                )
+                OR IS_MEMBER('db_owner') = 1;
+                """);
+
+            migrationBuilder.Sql("""
+                CREATE SECURITY POLICY app.TimeEntriesUserPolicy
+                ADD FILTER PREDICATE app.fn_filter_by_user_id(UserId) ON app.TimeEntries
+                WITH (STATE = ON);
+                """);
+
+            migrationBuilder.Sql("""
+                CREATE SECURITY POLICY app.ProjectUsersUserPolicy
+                ADD FILTER PREDICATE app.fn_filter_by_user_id(UserId) ON app.ProjectUsers
+                WITH (STATE = ON);
+                """);
+
+            migrationBuilder.Sql("""
+                CREATE SECURITY POLICY app.ProjectsUserPolicy
+                ADD FILTER PREDICATE app.fn_filter_projects_by_user(Id) ON app.Projects
+                WITH (STATE = ON);
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP SECURITY POLICY IF EXISTS app.ProjectsUserPolicy;");
+            migrationBuilder.Sql("DROP SECURITY POLICY IF EXISTS app.ProjectUsersUserPolicy;");
+            migrationBuilder.Sql("DROP SECURITY POLICY IF EXISTS app.TimeEntriesUserPolicy;");
+            migrationBuilder.Sql("DROP FUNCTION IF EXISTS app.fn_filter_projects_by_user;");
+            migrationBuilder.Sql("DROP FUNCTION IF EXISTS app.fn_filter_by_user_id;");
+
+            migrationBuilder.Sql("""
+                CREATE FUNCTION app.fn_filter_by_user_id(@UserId nvarchar(450))
+                RETURNS TABLE
+                WITH SCHEMABINDING
+                AS
+                RETURN SELECT 1 AS fn_result
+                WHERE @UserId = CAST(SESSION_CONTEXT(N'UserId') AS nvarchar(450));
+                """);
+
+            migrationBuilder.Sql("""
+                CREATE FUNCTION app.fn_filter_projects_by_user(@ProjectId int)
+                RETURNS TABLE
+                WITH SCHEMABINDING
+                AS
+                RETURN SELECT 1 AS fn_result
+                WHERE EXISTS (
+                    SELECT 1 FROM app.ProjectUsers
+                    WHERE ProjectId = @ProjectId
+                    AND UserId = CAST(SESSION_CONTEXT(N'UserId') AS nvarchar(450))
+                );
+                """);
+
+            migrationBuilder.Sql("""
+                CREATE SECURITY POLICY app.TimeEntriesUserPolicy
+                ADD FILTER PREDICATE app.fn_filter_by_user_id(UserId) ON app.TimeEntries
+                WITH (STATE = ON);
+                """);
+
+            migrationBuilder.Sql("""
+                CREATE SECURITY POLICY app.ProjectUsersUserPolicy
+                ADD FILTER PREDICATE app.fn_filter_by_user_id(UserId) ON app.ProjectUsers
+                WITH (STATE = ON);
+                """);
+
+            migrationBuilder.Sql("""
+                CREATE SECURITY POLICY app.ProjectsUserPolicy
+                ADD FILTER PREDICATE app.fn_filter_projects_by_user(Id) ON app.Projects
+                WITH (STATE = ON);
+                """);
+        }
+    }
+}

--- a/TimeTracker.Web/Program.cs
+++ b/TimeTracker.Web/Program.cs
@@ -130,4 +130,5 @@ app.MapClientEndpoints();
 app.MapAuthEndpoints();
 app.MapAdminEndpoints();
 
+
 app.Run();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,6 +95,22 @@ Two EF Core `DbContext`s, both targeting **SQL Server** (`TimeTrackerDb`):
 - `TimeEntry` stores `UserId` (string) rather than a navigation property to avoid cascade delete issues
 - **Mapster** handles entity ↔ DTO mapping, configured via per-feature `IRegister` classes scanned at startup
 
+### Row-Level Security
+
+RLS is applied to `app.TimeEntries`, `app.ProjectUsers`, and `app.Projects` via SQL Server security policies. `UserSessionContextInterceptor` sets `SESSION_CONTEXT(N'UserId')` before every EF Core command; the filter predicate functions read this value to restrict rows to the current user.
+
+**SA is not automatically exempt from RLS.** SQL Server applies security policies to all users including `sa` and `sysadmin` — there is no automatic bypass. The filter functions include `OR IS_MEMBER('db_owner') = 1` so that `sa` (which is `db_owner`) can query app tables in SSMS without needing to set session context first.
+
+**Querying from SSMS:** No setup needed — `sa` bypasses RLS via the `db_owner` check above.
+
+**Production:** The app database user is not `db_owner`, so the exemption has no effect in production.
+
+### Reference codes (PROJ-nnn / CLI-nnn)
+
+`Project` and `Client` each have a sequence-backed reference code: `seq_ProjectRef` → `PROJ-001`, `seq_ClientRef` → `CLI-001`. The sequence generates an integer (`ProjectSeqId` / `ClientSeqId`) stored in the row; a computed stored column formats it into the display string (`RefCode`).
+
+**Gaps are expected.** SQL Server sequences default to `CACHE 50` — 50 values are pre-allocated per block. If the server restarts before all 50 are used, unused values in that block are discarded and the next block starts at the next multiple of 50. A new client after 5 existing ones may get `CLI-051` rather than `CLI-006`. This is by design and a known DP-800 exam point: sequence values are never rolled back, and cached values are lost on restart. Gaps are acceptable for internal reference codes.
+
 ### Architecture
 
 **Vertical Slice Architecture** — no controllers, no repository layer.


### PR DESCRIPTION
## Summary

- Adds `seq_ProjectRef` and `seq_ClientRef` SQL SEQUENCE objects; integers stored in `ProjectSeqId`/`ClientSeqId` columns and formatted as `PROJ-nnn`/`CLI-nnn` via a stored computed column (`RefCode`)
- Exempts `db_owner` from RLS filter functions so SA can query data directly in SSMS
- Exposes `RefCode` on response DTOs and displays it as a muted caption on project/client cards, detail pages, and edit sheets
- Adds defence-in-depth tests asserting the service layer never sets or overwrites `RefCode`
- Removes `/api/diag` debug endpoint added during investigation
- Documents RLS db_owner exemption and sequence cache gap behaviour in `architecture.md`
- Forwards dev container SQL Server port 1434 for SSMS connectivity

## Test plan

- [ ] Run fast test suite: `dotnet test TimeTracker.Tests --filter "Category!=Container" && dotnet test TimeTracker.ComponentTests`
- [ ] Apply migration: `dotnet ef database update --context TimeTrackerDataContext` from `TimeTracker.Web`
- [ ] Create a project and client via the UI — verify `PROJ-nnn` / `CLI-nnn` appear as muted captions
- [ ] Open edit sheet for an existing project/client — verify ref code shows in drawer header
- [ ] Confirm SA can now query `app.Projects` and `app.Clients` in SSMS without RLS hiding all rows

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)