### PR TITLE
Bump NuGet dependencies (Dependabot PRs #278–#282) + fix session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -8,12 +8,14 @@ fi
 # Install .NET 10 via apt if not already present
 if ! command -v dotnet &> /dev/null || [[ "$(dotnet --version 2>/dev/null)" != 10.* ]]; then
   echo "Installing .NET 10 SDK..."
-  apt-get update --allow-unauthenticated \
-    -o Acquire::AllowInsecureRepositories=true \
-    -o Dir::Etc::sourcelist="sources.list" \
-    -o Dir::Etc::sourceparts="-" \
-    -qq 2>/dev/null || true
-  apt-get install -y dotnet-sdk-10.0 --allow-unauthenticated -qq
+  # Add the Microsoft package feed (required for dotnet-sdk-10.0 on Ubuntu 24.04)
+  . /etc/os-release
+  curl -fsSL "https://packages.microsoft.com/config/ubuntu/${VERSION_ID}/packages-microsoft-prod.deb" \
+    -o /tmp/packages-microsoft-prod.deb
+  dpkg -i /tmp/packages-microsoft-prod.deb
+  rm /tmp/packages-microsoft-prod.deb
+  apt-get update -qq 2>/dev/null || true
+  apt-get install -y dotnet-sdk-10.0 -qq
 fi
 
 echo ".NET version: $(dotnet --version)"

--- a/TimeTracker.Client/TimeTracker.Client.csproj
+++ b/TimeTracker.Client/TimeTracker.Client.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
-    <PackageReference Include="MudBlazor" Version="9.5.0" />
+    <PackageReference Include="MudBlazor" Version="9.6.0" />
     <PackageReference Include="Heron.MudCalendar" Version="4.0.0" />
     <PackageReference Include="Heron.MudTotalCalendar" Version="4.0.0" />
   </ItemGroup>

--- a/TimeTracker.ComponentTests/TimeTracker.ComponentTests.csproj
+++ b/TimeTracker.ComponentTests/TimeTracker.ComponentTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MudBlazor" Version="9.5.0" />
+    <PackageReference Include="MudBlazor" Version="9.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TimeTracker.Playwright/TimeTracker.Playwright.csproj
+++ b/TimeTracker.Playwright/TimeTracker.Playwright.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="Microsoft.Playwright.Xunit" Version="1.60.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.Playwright.Xunit" Version="1.61.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/TimeTracker.Tests/TimeTracker.Tests.csproj
+++ b/TimeTracker.Tests/TimeTracker.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/TimeTracker.Web/TimeTracker.Web.csproj
+++ b/TimeTracker.Web/TimeTracker.Web.csproj
@@ -15,10 +15,10 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.9" />
-    <PackageReference Include="MudBlazor" Version="9.5.0" />
+    <PackageReference Include="MudBlazor" Version="9.6.0" />
     <PackageReference Include="PublicHoliday" Version="3.13.0" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.16.4" />
-    <PackageReference Include="Mapster" Version="10.0.8" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.16.6" />
+    <PackageReference Include="Mapster" Version="10.0.10" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />


### PR DESCRIPTION
## Summary

- **MudBlazor** 9.5.0 → 9.6.0 (Web, Client, ComponentTests)
- **Scalar.AspNetCore** 2.16.4 → 2.16.6 (Web)
- **Mapster** 10.0.8 → 10.0.10 (Web)
- **Microsoft.Playwright.Xunit** 1.60.0 → 1.61.0 (Playwright)
- **Microsoft.NET.Test.Sdk** 18.6.0 → 18.7.0 (Tests, ComponentTests, Playwright)
- **Fix `.claude/hooks/session-start.sh`**: the hook was failing silently because it called `apt-get install dotnet-sdk-10.0` without first registering the Microsoft package feed. Added a step to download and install `packages-microsoft-prod.deb` for the detected Ubuntu version before running `apt-get update`.

Closes #278, #279, #280, #281, #282

## Test plan

- [x] 173 unit tests passing (`dotnet test TimeTracker.Tests --filter "Category!=Container"`)
- [x] 22 component tests passing (`dotnet test TimeTracker.ComponentTests`)

---
_Generated by [Claude Code](https://claude.ai/code/session_017KZdRP8XfCXAP62kMuYgqS)_