### PR TITLE
Fix high-severity Microsoft.OpenApi DoS vulnerability

### DIFF
--- a/TimeTracker.Web/TimeTracker.Web.csproj
+++ b/TimeTracker.Web/TimeTracker.Web.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.6" />
     <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.9" />
     <PackageReference Include="MudBlazor" Version="9.6.0" />


### PR DESCRIPTION
## Summary
- `Microsoft.AspNetCore.OpenApi` 10.0.9 transitively pulls in `Microsoft.OpenApi` 2.0.0, which has a high-severity advisory: [GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc) (CVE-2026-49451) — a circular schema reference in an OpenAPI document can crash the process via stack overflow.
- Added a direct `PackageReference` to `Microsoft.OpenApi` 2.7.6 (fixed in 2.7.5+) in `TimeTracker.Web.csproj` so NuGet resolves the patched version instead of the vulnerable transitive one.
- This wasn't previously caught by Dependabot because the repo has no `packages.lock.json`, so GitHub's dependency graph can't see transitive NuGet dependencies (only direct `PackageReference` entries) — `Microsoft.OpenApi` never appears explicitly in any project file, only inside `Microsoft.AspNetCore.OpenApi`'s own nuspec.

## Test plan
- [x] `dotnet restore` — NU1903 vulnerability warning is gone
- [x] `dotnet list package --vulnerable --include-transitive` — reports clean across all 7 projects
- [x] `dotnet build TimeTracker.sln` — succeeds, 0 warnings/errors
- [x] `dotnet test TimeTracker.Tests --filter "Category!=Container"` — 173/173 passed
- [x] `dotnet test TimeTracker.ComponentTests` — 22/22 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01266juWqCwahdALwWGQUV45)_