### PR TITLE
chore: ignore Microsoft.OpenApi major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,9 @@ updates:
           - "Microsoft.EntityFrameworkCore*"
           - "Microsoft.AspNetCore.Identity.EntityFrameworkCore"
           - "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore"
+    ignore:
+      # Microsoft.AspNetCore.OpenApi 10.0.9 pins Microsoft.OpenApi >= 2.0.0 and has not
+      # been updated for the 3.x line yet (upstream release notes: 3.x support lands in
+      # a future ASP.NET Core version). Stay on 2.x until that catches up.
+      - dependency-name: "Microsoft.OpenApi"
+        update-types: ["version-update:semver-major"]

--- a/docs/technical-debt.md
+++ b/docs/technical-debt.md
@@ -47,6 +47,12 @@ Every entry records a decision that was forced by a constraint (cost, tier limit
 |---|--------|----------|-----------|-------------|-----------------|
 | TD21 | | No CDN, WAF, or custom domain | Azure App Service F1 free tier does not support custom domains. Cloudflare free tier URL redirections do not work. The app is served directly at `timetracker-zak.azurewebsites.net`. | No custom domain. No CDN caching. No DDoS mitigation. No WAF. | Upgrade App Service to at least Basic (B1) to unlock custom domain binding, then add Cloudflare free plan (CDN + basic DDoS) or Azure Front Door for WAF. See [D017](decisions.md#d017-cloudflare-free-plan-over-paid-cdnwaf). |
 
+### Dependencies
+
+| # | Status | Decision | Constraint | Consequence | Proper solution |
+|---|--------|----------|-----------|-------------|-----------------|
+| TD27 | | `Microsoft.OpenApi` pinned to the 2.x line, major-version bumps ignored in Dependabot | `Microsoft.AspNetCore.OpenApi` 10.0.9 (ASP.NET Core's built-in OpenAPI generation) declares a dependency on `Microsoft.OpenApi >= 2.0.0`, not 3.x. Upstream release notes for `Microsoft.OpenApi` 3.0.0 state 3.x support "will be implemented in a future version of ASP.NET". Taking 3.x now risks breaking Swagger generation. | Dependabot PR #290 (2.7.6 → 3.8.0) was closed. `.github/dependabot.yml` now ignores `semver-major` updates for `Microsoft.OpenApi`, so it will not resurface until manually revisited. No automated signal exists for when ASP.NET Core adds 3.x support. | Revisit when `Microsoft.AspNetCore.OpenApi` itself gets bumped to a version that requires `Microsoft.OpenApi` 3.x (a NuGet restore conflict at that point is the natural trigger) — then remove the ignore rule and take the major bump. |
+
 ---
 
 ## Resolved


### PR DESCRIPTION
## Summary
- Closes #290 for the reason described below and stops Dependabot from re-proposing it weekly.
- `Microsoft.AspNetCore.OpenApi` 10.0.9 pins `Microsoft.OpenApi >= 2.0.0`; the 3.x line isn't supported by ASP.NET Core's built-in OpenAPI generation yet (confirmed via the package's own nuspec dependency group, and upstream release notes state 3.x support "will be implemented in a future version of ASP.NET").
- Adds a Dependabot `ignore` rule for `semver-major` updates to `Microsoft.OpenApi`.
- Logs TD27 in `docs/technical-debt.md` so the ignore rule gets revisited once ASP.NET Core adopts 3.x — the natural trigger is a future `Microsoft.AspNetCore.OpenApi` bump that itself requires `Microsoft.OpenApi` 3.x.

## Test plan
- [x] Docs/config-only change, no app code touched.