### PR TITLE
chore: bump Microsoft.OpenApi to 2.10.0 (latest 2.x)

### DIFF
--- a/TimeTracker.Tests/packages.lock.json
+++ b/TimeTracker.Tests/packages.lock.json
@@ -738,8 +738,8 @@
       },
       "Microsoft.OpenApi": {
         "type": "Transitive",
-        "resolved": "2.7.6",
-        "contentHash": "suM/dwWsQC8DEOcTeLQvKpXP0c2j/hllKD++IqCavZENr8Df1IgVDMCJRMZd2pGI1NSxMDWrhuPQXG+ZMRrSZA=="
+        "resolved": "2.10.0",
+        "contentHash": "tD7ve8JrWfJ+aRfW7J9yDj8t6pbMOzdr8nSc5BlIZaIRxqZZ67RJ8J69//Tx6HHSNFsqomBbipkPP20opnqvMg=="
       },
       "Microsoft.SqlServer.Server": {
         "type": "Transitive",
@@ -1019,7 +1019,7 @@
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.SqlServer": "[10.0.9, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.0.9, )",
-          "Microsoft.OpenApi": "[2.7.6, )",
+          "Microsoft.OpenApi": "[2.10.0, )",
           "MudBlazor": "[9.7.0, )",
           "PublicHoliday": "[3.13.0, )",
           "Scalar.AspNetCore": "[2.16.11, )",

--- a/TimeTracker.Web/TimeTracker.Web.csproj
+++ b/TimeTracker.Web/TimeTracker.Web.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.7.6" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.9" />
     <PackageReference Include="MudBlazor" Version="9.7.0" />

--- a/TimeTracker.Web/packages.lock.json
+++ b/TimeTracker.Web/packages.lock.json
@@ -113,9 +113,9 @@
       },
       "Microsoft.OpenApi": {
         "type": "Direct",
-        "requested": "[2.7.6, )",
-        "resolved": "2.7.6",
-        "contentHash": "suM/dwWsQC8DEOcTeLQvKpXP0c2j/hllKD++IqCavZENr8Df1IgVDMCJRMZd2pGI1NSxMDWrhuPQXG+ZMRrSZA=="
+        "requested": "[2.10.0, )",
+        "resolved": "2.10.0",
+        "contentHash": "tD7ve8JrWfJ+aRfW7J9yDj8t6pbMOzdr8nSc5BlIZaIRxqZZ67RJ8J69//Tx6HHSNFsqomBbipkPP20opnqvMg=="
       },
       "MudBlazor": {
         "type": "Direct",


### PR DESCRIPTION
## Summary
- Bumps `Microsoft.OpenApi` from 2.7.6 to 2.10.0, the latest release in the 2.x line (Dependabot only offered the unsupported 3.x major — see #294/TD27).
- Stays within `Microsoft.AspNetCore.OpenApi` 10.0.9's declared dependency range (`>= 2.0.0`).

## Test plan
- [x] `dotnet build TimeTracker.sln` — clean
- [x] `dotnet test TimeTracker.Tests --filter "Category!=Container"` — 173 passed
- [x] `dotnet test TimeTracker.ComponentTests` — 22 passed