### PR TITLE
debug: add verbose tracing to backup push step

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -92,8 +92,12 @@ jobs:
 
       - name: Push to private backup repo
         run: |
+          set -x
           git clone https://x-access-token:${{ secrets.BACKUP_REPO_TOKEN }}@github.com/${{ github.repository_owner }}/${{ vars.BACKUP_REPO_NAME }}.git backup-repo
+          echo "clone exit: $?"
+          ls -la backup-repo
           cp ${{ steps.export.outputs.file }} backup-repo/
+          echo "cp exit: $?"
           cd backup-repo
           find . -name "backup-*.bacpac" | while read f; do
             d=$(basename "$f" .bacpac | sed 's/backup-//')
@@ -102,8 +106,11 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           git add .
+          git status
           git diff --staged --quiet || git commit -m "backup: ${{ steps.export.outputs.file }}"
-          git push
+          echo "commit exit: $?"
+          GIT_CURL_VERBOSE=1 git push
+          echo "push exit: $?"
 
       - name: Close SQL firewall
         if: always()


### PR DESCRIPTION
## Summary
- Temporary diagnostic PR to capture the real error from the "Push to private backup repo" step in the Database Backup workflow, which has been failing silently every day since 2026-06-17.
- Adds `set -x`, exit-code echoes, and `GIT_CURL_VERBOSE=1` to the git push step.
- Will be reverted/replaced by the actual fix once the root cause is identified.

## Test plan
- [ ] Merge and manually trigger `workflow_dispatch` on main
- [ ] Capture logs to identify root cause
- [ ] Follow-up PR with real fix + removal of debug tracing