### PR TITLE
fix: Database Backup workflow failing every day due to set -e in retention loop

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -92,25 +92,21 @@ jobs:
 
       - name: Push to private backup repo
         run: |
-          set -x
           git clone https://x-access-token:${{ secrets.BACKUP_REPO_TOKEN }}@github.com/${{ github.repository_owner }}/${{ vars.BACKUP_REPO_NAME }}.git backup-repo
-          echo "clone exit: $?"
-          ls -la backup-repo
           cp ${{ steps.export.outputs.file }} backup-repo/
-          echo "cp exit: $?"
           cd backup-repo
           find . -name "backup-*.bacpac" | while read f; do
             d=$(basename "$f" .bacpac | sed 's/backup-//')
-            [[ $(date -d "$d" +%s 2>/dev/null) -lt $(date -d "30 days ago" +%s) ]] && rm "$f"
+            filedate=$(date -d "$d" +%s 2>/dev/null) || continue
+            if [ "$filedate" -lt "$(date -d "30 days ago" +%s)" ]; then
+              rm "$f"
+            fi
           done
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           git add .
-          git status
           git diff --staged --quiet || git commit -m "backup: ${{ steps.export.outputs.file }}"
-          echo "commit exit: $?"
-          GIT_CURL_VERBOSE=1 git push
-          echo "push exit: $?"
+          git push
 
       - name: Close SQL firewall
         if: always()


### PR DESCRIPTION
## Summary
- Root cause of the daily Database Backup failures (since ~2026-06-17): the retention-cleanup loop used a bare `[[ cond ]] && rm "$f"` statement. Whenever a backup file was newer than 30 days (true on every run, since the file just copied is always today's date), `[[ ]]` evaluated false and returned exit code 1. Under `bash -e` this aborted the step immediately, before `git commit`/`git push` ever ran.
- The SqlPackage export, Azure login, and firewall steps were all working correctly the whole time — the failure was purely in the retention-pruning shell logic.
- Rewrites the loop with a proper `if` so a "nothing to delete" result no longer kills the script.
- Removes the temporary diagnostic tracing (`set -x`, exit-code echoes, `GIT_CURL_VERBOSE`) added in #297 for root-causing.

## Test plan
- [x] Diagnostic run (via #297, merged then reverted here) confirmed the exact failing line: `[[ 1784073600 -lt 1781556353 ]]` returning 1 and killing the script under `set -e`.
- [ ] Trigger `workflow_dispatch` on main after merge and confirm the backup pushes successfully to `TimeTracker-backups`.

Closes #17