### PR TITLE
Fix moderate-severity AngleSharp mXSS advisory

### DIFF
--- a/TimeTracker.ComponentTests/TimeTracker.ComponentTests.csproj
+++ b/TimeTracker.ComponentTests/TimeTracker.ComponentTests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="bunit" Version="2.7.2" />
+    <PackageReference Include="AngleSharp" Version="1.5.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/TimeTracker.ComponentTests/packages.lock.json
+++ b/TimeTracker.ComponentTests/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     "net10.0": {
+      "AngleSharp": {
+        "type": "Direct",
+        "requested": "[1.5.0, )",
+        "resolved": "1.5.0",
+        "contentHash": "REAdFOAlTxr6yqmxWFFLLMB/+uvIS3N6tXXUAWjoexA0LsQB/CfZYadg+z+DkcpAwJk8gF1VF4YLsq4U1Gficg=="
+      },
       "bunit": {
         "type": "Direct",
         "requested": "[2.7.2, )",
@@ -65,11 +71,6 @@
         "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
-      },
-      "AngleSharp": {
-        "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "6ph8mpaQx0KL0COYRt0kI8MB9gSp1PtKijKMhJU//+aVFgKAJLKDesG/+26JSaVCOrHNgPf12wpfoyRcMYOeXg=="
       },
       "AngleSharp.Css": {
         "type": "Transitive",


### PR DESCRIPTION
## Summary
- `TimeTracker.ComponentTests` pulled `AngleSharp` 1.4.0 transitively via `bunit` 2.7.2, flagged for [GHSA-pgww-w46g-26qg](https://github.com/advisories/GHSA-pgww-w46g-26qg) (CVE-2026-54570) — a moderate-severity mutated XSS (mXSS) sanitizer bypass via MathML `<annotation-xml>` parsing. Fixed in 1.5.0.
- Added a direct `PackageReference` to `AngleSharp` 1.5.0 in `TimeTracker.ComponentTests.csproj` so NuGet resolves the patched version instead of the vulnerable transitive one.
- Low practical exploitability here — bUnit uses AngleSharp to parse rendered test output for assertions, not to sanitize untrusted user HTML in the shipped app — but the fix is a one-line pin with no other cost.

## Test plan
- [x] `dotnet list package --vulnerable --include-transitive` — clean across all projects
- [x] `dotnet restore --locked-mode` — succeeds
- [x] `dotnet build TimeTracker.sln` — 0 warnings, 0 errors
- [x] `dotnet test TimeTracker.Tests --filter "Category!=Container"` — 173/173 passed
- [x] `dotnet test TimeTracker.ComponentTests` — 22/22 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01266juWqCwahdALwWGQUV45)_