### PR TITLE
Block Claude from merging pull requests

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,10 @@
 {
+  "permissions": {
+    "deny": [
+      "mcp__github__merge_pull_request",
+      "Bash(gh pr merge*)"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary
- Adds a `permissions.deny` rule to `.claude/settings.json` blocking `mcp__github__merge_pull_request` and `gh pr merge`.
- Project-level (checked into the repo), so it applies in every environment — local dev, remote sessions, anyone else working in this repo — not just wherever it was originally configured.
- Claude can still prepare, fix, verify, and open PRs; merging is always a human action from here on.


---
_Generated by [Claude Code](https://claude.ai/code/session_01266juWqCwahdALwWGQUV45)_