### PR TITLE
fix: CodeQL workflow missing .NET SDK setup

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -97,6 +97,12 @@ jobs:
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
     - if: matrix.build-mode == 'manual'
+      name: Setup .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        global-json-file: global.json
+
+    - if: matrix.build-mode == 'manual'
       name: Build
       shell: bash
       run: dotnet build --configuration Release


### PR DESCRIPTION
## Summary
- CodeQL's manual C# build step ran `dotnet build` directly without installing a .NET SDK, relying on whatever happened to be preinstalled on the runner image
- `global.json` pins an exact SDK patch (`10.0.109`) with `rollForward: disable`, so when the runner image updated its preinstalled SDKs (now `10.0.110`/`204`/`302`), resolution failed and the workflow broke
- Added `actions/setup-dotnet@v5` with `global-json-file: global.json` before the build step, matching the pattern already used in `ci.yml`

## Test plan
- [ ] Confirm the CodeQL Analyze (csharp) job succeeds on this PR