### PR TITLE
chore: allow manual CodeQL Advanced runs via workflow_dispatch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,7 @@ on:
       - '**/*.css'
   schedule:
     - cron: '16 6 * * 6'
+  workflow_dispatch:
 
 jobs:
   analyze:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch:` trigger to `codeql.yml` so the CodeQL Advanced workflow can be run on demand from the Actions tab or `gh workflow run`
- Currently the workflow only runs on push/PR (gated by `paths` filters on `.cs`/`.razor`/`.csproj`/`.sln`/`.css`) or the weekly Saturday cron schedule — there was no way to manually verify a workflow-only change (like the recent SDK setup fix in #307) without waiting for the schedule

## Test plan
- [ ] Confirm "Run workflow" button appears for CodeQL Advanced in the Actions tab
- [ ] Manually trigger and confirm the run succeeds