### PR TITLE
Group ASP.NET Core packages in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,13 @@ updates:
           - "Microsoft.EntityFrameworkCore*"
           - "Microsoft.AspNetCore.Identity.EntityFrameworkCore"
           - "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore"
+      # The rest of the ASP.NET Core packages ship together in .NET's monthly patch
+      # releases (e.g. 10.0.9 -> 10.0.10 across Web, Client and ComponentTests on the
+      # same day). Grouping avoids 4-6 near-identical separate PRs each month. Listed
+      # after entity-framework-core so those packages keep going to that group instead.
+      aspnetcore-runtime:
+        patterns:
+          - "Microsoft.AspNetCore.*"
     ignore:
       # Microsoft.AspNetCore.OpenApi 10.0.9 pins Microsoft.OpenApi >= 2.0.0 and has not
       # been updated for the 3.x line yet (upstream release notes: 3.x support lands in


### PR DESCRIPTION
## Summary
- Adds an `aspnetcore-runtime` Dependabot group matching `Microsoft.AspNetCore.*`, following the same pattern as the existing `entity-framework-core` group.
- These packages ship together on .NET's monthly patch release cadence — this week alone Dependabot opened 4 separate near-identical PRs (#311–#314) all bumping 10.0.9 → 10.0.10 on the same day.
- Listed after `entity-framework-core` in the config so those packages (which also match `Microsoft.AspNetCore.*`, e.g. `Microsoft.AspNetCore.Identity.EntityFrameworkCore`) keep routing to that group instead — Dependabot assigns each dependency to the first matching group.

## Test plan
- [x] Validated YAML syntax
- Not applicable: this is a Dependabot config file, not app code — no build/test impact.


---
_Generated by [Claude Code](https://claude.ai/code/session_01266juWqCwahdALwWGQUV45)_