### PR TITLE
Auto-fix stale lock files on Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-lockfile-fix.yml
+++ b/.github/workflows/dependabot-lockfile-fix.yml
@@ -1,0 +1,39 @@
+name: Dependabot Lock File Fix
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+
+jobs:
+  fix-lockfile:
+    name: Regenerate lock file
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          global-json-file: global.json
+
+      - name: Regenerate lock files
+        run: dotnet restore TimeTracker.sln --force-evaluate
+
+      - name: Commit and push if lock files changed
+        run: |
+          if git diff --quiet -- '**/packages.lock.json'; then
+            echo "Lock files already consistent - nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -- '**/packages.lock.json'
+          git commit -m "Regenerate lock files for Dependabot bump" -m "Fixes a known Dependabot limitation (dependabot/dependabot-core#13950): the lock file of the directly-edited project gets updated, but other projects that transitively pull the same package back in via ProjectReference do not."
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/dependabot-lockfile-fix.yml`, which runs on every Dependabot PR (`pull_request: [opened, synchronize]`, gated on `github.actor == 'dependabot[bot]'`).
- Root cause: Dependabot updates the lock file of the project it directly edits, but not other projects that transitively pull the same package back in via `ProjectReference` — a known, longstanding limitation ([dependabot-core#13950](https://github.com/dependabot/dependabot-core/issues/13950), [#10863](https://github.com/dependabot/dependabot-core/issues/10863), [#11197](https://github.com/dependabot/dependabot-core/issues/11197), [#12318](https://github.com/dependabot/dependabot-core/issues/12318)). We've hit this on essentially every NuGet bump this repo has had since lock files were introduced.
- The workflow runs `dotnet restore TimeTracker.sln --force-evaluate` and, if any `packages.lock.json` changed, commits and pushes the fix straight back to the PR branch — self-healing before CI's `Build & Test` job even runs.
- Uses the default `GITHUB_TOKEN` with `permissions: contents: write` — GitHub has respected the `permissions` key for Dependabot-triggered `pull_request` runs since October 2021, so no PAT or extra secret is needed.

## Test plan
- [x] Validated YAML syntax
- [x] Manually ran the exact restore + diff logic this workflow performs against a live stale Dependabot PR (#319, `Microsoft.OpenApi` bump) — correctly detected the stale `TimeTracker.Tests/packages.lock.json`, regenerated it, and the resulting fix passed `--locked-mode` restore, build, and the full test suite (173/173)
- [x] Verified the "already consistent" path is a no-op (ran against current `main`, confirmed clean diff, no false-positive commits)
- Real end-to-end proof (workflow actually firing on a live Dependabot PR and pushing) will happen naturally the next time Dependabot opens a PR, since this can't be triggered synthetically from outside the Actions runner.


---
_Generated by [Claude Code](https://claude.ai/code/session_01266juWqCwahdALwWGQUV45)_