### PR TITLE
test: pin container tests to the dev container SQL Server and guard the drift (#323)

### DIFF
--- a/TimeTracker.Tests/Infrastructure/SqlServerFixture.cs
+++ b/TimeTracker.Tests/Infrastructure/SqlServerFixture.cs
@@ -21,7 +21,15 @@ public class SqlServerCollection : ICollectionFixture<SqlServerFixture> { }
 /// </summary>
 public class SqlServerFixture : IAsyncLifetime
 {
-    private readonly MsSqlContainer _container = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest")
+    /// <summary>
+    /// The SQL Server image these tests run against. Must match the dev container image in
+    /// docker-compose.yml — SqlServerVersionConsistencyTests fails the build if they diverge.
+    /// RLS behaviour is engine-version sensitive, so testing on a different engine to the one
+    /// used for development proves less than it appears to (see issue #323).
+    /// </summary>
+    public const string SqlServerImage = "mcr.microsoft.com/mssql/server:2025-latest";
+
+    private readonly MsSqlContainer _container = new MsSqlBuilder(SqlServerImage)
         .WithAutoRemove(true)
         .Build();
 

--- a/TimeTracker.Tests/Infrastructure/SqlServerVersionConsistencyTests.cs
+++ b/TimeTracker.Tests/Infrastructure/SqlServerVersionConsistencyTests.cs
@@ -1,0 +1,56 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace TimeTracker.Tests.Infrastructure;
+
+/// <summary>
+/// Guards against the class of drift described in issue #323: the Testcontainers fixture and the
+/// dev container silently running different SQL Server engines.
+///
+/// RlsIntegrationTests and MigrationSmokeTests are the only automated proof that the security
+/// policies behave. If they run on a different engine to the one used for development, that proof
+/// is weaker than it looks — and nothing else in the suite would notice.
+///
+/// This test needs no Docker and runs in the fast loop, so the two can never diverge unnoticed
+/// again.
+/// </summary>
+public class SqlServerVersionConsistencyTests
+{
+    [Fact]
+    public void FixtureImage_MatchesDevContainerImage()
+    {
+        var composePath = Path.Combine(FindRepositoryRoot(), "docker-compose.yml");
+        Assert.True(File.Exists(composePath), $"docker-compose.yml not found at {composePath}");
+
+        var compose = File.ReadAllText(composePath);
+        var match = Regex.Match(compose, @"image:\s*(?<image>mcr\.microsoft\.com/mssql/server:\S+)");
+
+        Assert.True(match.Success,
+            "Could not find a SQL Server image in docker-compose.yml. If the dev container no " +
+            "longer uses one, this guard needs updating.");
+
+        var composeImage = match.Groups["image"].Value;
+
+        Assert.True(composeImage == SqlServerFixture.SqlServerImage,
+            $"SQL Server image drift.{Environment.NewLine}" +
+            $"  docker-compose.yml:            {composeImage}{Environment.NewLine}" +
+            $"  SqlServerFixture.SqlServerImage: {SqlServerFixture.SqlServerImage}{Environment.NewLine}" +
+            "Container tests would run against a different engine to the dev container. " +
+            "Update both, and docs/testcontainers.md alongside them.");
+    }
+
+    /// <summary>
+    /// Walks up from the test assembly location until the directory containing the solution is
+    /// found, so the test works regardless of build configuration or working directory.
+    /// </summary>
+    private static string FindRepositoryRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "TimeTracker.sln")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);
+        return dir.FullName;
+    }
+}

--- a/docs/plans/permission-model-review.md
+++ b/docs/plans/permission-model-review.md
@@ -1,0 +1,188 @@
+# Permission model review
+
+> **Status: discussion document. No decision made.**
+>
+> The defects found during this review are tracked as issues (#337–#341) and are actionable
+> independently. The architectural question in Part 3 is **open** — nothing here commits to it.
+
+---
+
+## Part 1 — The placement principle
+
+Three tests decide whether a rule belongs in Row-Level Security rather than the application:
+
+1. **Is it invariant?** Does it ever have a legitimate exception?
+2. **Is breach catastrophic?** Or merely embarrassing?
+3. **Is it join-free?** Or does the predicate need `EXISTS (SELECT … JOIN …)` evaluated per row?
+
+Tenant isolation passes all three. *"Your rows only"* passes only in an application where users
+genuinely never share — which this one is not, because team rollups are wanted. Per-project
+visibility fails all three.
+
+This is the root of the current strain: **a variable business rule is encoded as an invariant.**
+Rules like that do not fail loudly. They under-report.
+
+### Where each rule belongs
+
+| Layer | Enforces | Test |
+|---|---|---|
+| RLS | Tenant boundary, nothing else | Invariant + catastrophic + join-free |
+| EF global query filters | Unconditional truths (soft delete) | Never has an exception |
+| Policy + claim | Coarse capability ("may manage members") | Fixed for the session |
+| Resource handler | Per-resource permission ("may manage *this* project") | Needs the resource in hand |
+| Service `WHERE` | Ownership ("is this record mine") | It is a column, not a role |
+
+---
+
+## Part 2 — What the current model costs
+
+| Symptom | Cause |
+|---|---|
+| #167 budget bar shows one person's hours as if they were the project's | `SUM` over RLS-filtered rows returns a plausible partial total, no error |
+| `GetProjectUsers` returns only yourself | `ProjectUsersUserPolicy` |
+| Admin Projects and Trash pages omit unassigned projects **in production** | `ProjectsUserPolicy` (#337) |
+
+`docs/rls-security-model.md` already documented the ceiling — *"Anything team-wide is blocked by
+design"* — with both casualties listed. This review acts on a diagnosis that was already made.
+
+### Tracked defects
+
+| Issue | Defect |
+|---|---|
+| #337 | `ProjectsUserPolicy` hides unassigned projects from admin pages in production |
+| #338 | `ProjectUser` time-allocation gate not enforced on writes |
+| #339 | Role change does not rotate the security stamp — 30-minute admin retention |
+| #340 | Session context leaks across pooled connections when there is no user |
+| #341 | Endpoint authorization corrections (`/api/dev/login`, `revoke-sessions`, project users) |
+
+None of these depend on the architectural question. They are true in any direction.
+
+### What is sound
+
+The **machinery** is correct and transferable: the per-command interceptor (correctly handling
+connection pooling), `rls_bypass` as an explicit revocable grant rather than an implicit `db_owner`
+exemption, the Testcontainers harness with two differently-privileged logins, the audit trail.
+
+What is misplaced is the predicate — the `WHERE` clause, not the mechanism.
+
+---
+
+## Part 3 — The open question: does a tenant tier happen?
+
+**Undecided. Recorded here so the reasoning is not lost, not because it is agreed.**
+
+ADR-023 declares multi-tenancy explicitly out of scope, and made that call well on product grounds.
+Adopting a tenant tier would be **changing the goal** — from "cheapest correct personal app" to
+"reference implementation worth pointing at" — not correcting an error. If it happens, ADR-023
+should be superseded explicitly, recording that learning value was the deciding factor.
+
+### If it happens, the shape
+
+```
+Tenant(Id, Name, Slug)
+TenantMembership(TenantId, UserId, TenantRole)              -- Owner | Admin | Member
+Project(Id, TenantId, Name)
+ProjectMembership(ProjectId, TenantId, UserId, ProjectRole) -- Manager | Member | Viewer
+WorkRecord(Id, TenantId, ProjectId, UserId, …)
+```
+
+One predicate function, `FILTER` + `BLOCK`, applied to every tenant-scoped table. Per-user
+visibility moves to the application tier, which is what unblocks team rollups (#167).
+
+**Free win:** `Clients` gets RLS for the first time. ADR-020 deferred it because it needed a two-hop
+predicate; with a direct `TenantId` the same one-line predicate covers it.
+
+### RBAC notes
+
+`AspNetUserRoles` is `(UserId, RoleId)` — there is nowhere to put a tenant. Roles stored there are
+global to the user, live in a different schema to tenant membership with no FK between them, and
+cannot be protected by RLS. `UserManagementService`'s last-admin guard (`GetUsersInRoleAsync`)
+would count admins across all tenants.
+
+Role authority would need to move into the application schema. Identity keeps doing authentication;
+it stops being the authorization store.
+
+Two role axes, and one of them cannot be a claim: a user might manage 3 of 50 projects, and
+per-project claims exceed the ~4KB cookie ceiling. That constraint *forces* resource-based
+authorization rather than it being a stylistic choice.
+
+### Honest cost
+
+Multi-tenancy is permanent complexity, not just build cost. Every new table needs a `TenantId` and a
+policy. Every migration needs bypass discipline. Every aggregate needs checking. On an application
+with one real user, that is carried forever for a tenant count of one.
+
+### Prerequisites either way
+
+- **#323** must be settled first. The container suite is the only automated proof the policies
+  behave, and until it has actually run against the engine used for development, it proves less
+  than it appears to. PR #336 makes the versions agree but does not verify them.
+- The spike referenced in `docs/rls-security-model.md` as existing (`RlsPredicateSpike` in
+  `TimeTracker.Tests/Infrastructure/`) **does not exist**. The open questions it was meant to answer
+  — whether `BLOCK` predicates behave as expected against EF-generated `UPDATE`s, whether the
+  interceptor's separate `sp_set_session_context` command shares the session under a `BLOCK`
+  predicate — are unanswered.
+- Any backfill is the highest-risk step. A `FILTER` predicate applies to `UPDATE`, so an unbypassed
+  backfill touches zero rows, reports success, and raises nothing. It must run under `rls_bypass`
+  and assert its own completeness rather than trusting the row count.
+
+---
+
+## Part 4 — Test strategy
+
+RLS cannot be unit tested at any provider — it is a SQL Server engine feature. EF Core InMemory has
+no policies and no `SESSION_CONTEXT`, so the entire RLS layer is invisible to
+`--filter "Category!=Container"`.
+
+Microsoft recommend against EF Core InMemory generally: it is not relational, does not enforce
+foreign keys or unique constraints, and lets tests pass that would fail against SQL Server.
+
+If the suite is reworked, the principle worth holding is:
+
+> **No test uses a fake database. Tests either use no database at all, or a real one.**
+
+| Tier | What lives there | Docker? |
+|---|---|---|
+| No DB | `AwardRateResolver`, Mapster config, endpoint policy wiring, middleware, and — if built — permission maps and `AuthorizationHandler`s | No |
+| Real SQL Server | `TimeEntryService`, `ProjectService`, `ClientService`, `ProjectUser`, Identity-backed tests, RLS, migration smoke | Yes |
+
+Roughly half the current files need no database at all. Running an `AuthorizationHandler` test
+against SQL Server buys nothing — it is a pure class.
+
+Two gotchas for that migration:
+
+- **Respawn must connect as `rls_bypass`.** Reset works by `DELETE`, and a `FILTER` predicate
+  applies to `DELETE` — a reset connection without the bypass deletes only its own rows, reports
+  success, and leaves the table dirty. `timetracker_rls_bypass_test` already exists for this.
+- **`AuthEndpointAuthTests` uses InMemory only to satisfy Identity DI**, not to test data. It
+  belongs in the no-DB tier.
+
+Note the cost: dropping InMemory entirely means every test requires Docker, and remote sessions
+(Claude Code on the web) lose the ability to run any test.
+
+### Properties, not percentages
+
+Coverage measures which lines ran, not which guarantees hold. For a permission system the useful
+question is which properties are proven, and by which suite:
+
+| Property | Suite |
+|---|---|
+| Cross-tenant read returns nothing | Container |
+| Cross-tenant write throws (`BLOCK`) | Container |
+| Unset session context returns nothing — fails closed | Container |
+| Non-member cannot log time to a project | Unit |
+| Non-manager cannot see others' entries | Unit |
+| A user can always edit their own record | Unit |
+| Demoted admin loses access | Integration |
+| Every endpoint carries its intended policy | Metadata |
+
+There is currently no coverage measurement at all — that is #234.
+
+---
+
+## Related
+
+- `docs/rls-security-model.md` — how the current policies work, and the gaps it already records
+- `docs/decisions.md` — ADR-020 (RLS), ADR-023 (single-tenant), ADR-024 (`ProjectUser` as gate),
+  ADR-031 (pipeline migrations), ADR-033 (`rls_bypass` role)
+- Issues #337–#341 (defects), #323 (engine parity), #167 (blocked by current design), #234 (coverage)

--- a/docs/testcontainers.md
+++ b/docs/testcontainers.md
@@ -27,7 +27,11 @@ The entry point is `SqlServerFixture` in `TimeTracker.Tests/Infrastructure/SqlSe
 ```csharp
 public class SqlServerFixture : IAsyncLifetime
 {
-    private readonly MsSqlContainer _container = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest")
+    // Must match the dev container image in docker-compose.yml.
+    // SqlServerVersionConsistencyTests fails the build if they diverge.
+    public const string SqlServerImage = "mcr.microsoft.com/mssql/server:2025-latest";
+
+    private readonly MsSqlContainer _container = new MsSqlBuilder(SqlServerImage)
         .WithAutoRemove(true)
         .Build();
 
@@ -55,6 +59,26 @@ public class SqlServerFixture : IAsyncLifetime
 You don't need to know the port — `GetConnectionString()` gives it to you.
 
 **`WithAutoRemove(true)`** tells Docker to delete the container when the process exits, even if `DisposeAsync` didn't run (e.g. the test runner crashed). Belt-and-suspenders cleanup.
+
+### Why the image version is pinned to a constant
+
+`RlsIntegrationTests` and `MigrationSmokeTests` are the only automated proof that the security
+policies behave. RLS behaviour is engine-version sensitive, so if those tests run against a
+different SQL Server than the one used for development, the proof is weaker than it looks — and
+nothing else in the suite would notice.
+
+That is exactly what happened: `docker-compose.yml` was upgraded from 2022 to 2025 (commit
+`77188e0`) and the fixture was never touched, so the container suite spent months validating an
+engine nobody develops against ([#323](https://github.com/zkarachiwala/TimeTracker/issues/323)).
+
+`SqlServerVersionConsistencyTests` now parses `docker-compose.yml` and asserts it matches
+`SqlServerFixture.SqlServerImage`. It needs no Docker and runs in the fast loop, so the two cannot
+silently diverge again. If you change one, that test tells you to change the other — and to update
+this document.
+
+**Production is Azure SQL Database, which matches neither container version exactly.** Pinning to
+the dev container image closes the dev/test gap; it does not close the test/production gap. That
+one is inherent to using a container to stand in for a managed service.
 
 ---
 


### PR DESCRIPTION
Closes #323 once the container suite has been verified locally — see caveat below.

## Problem

`docker-compose.yml` moved to SQL Server 2025 in `77188e0`. `SqlServerFixture` was never updated and has been on 2022 since the commit that created it — its only commit.

`RlsIntegrationTests` and `MigrationSmokeTests` are the only automated proof the security policies behave. They have been validating an engine nobody develops against, and nothing in the suite would have noticed.

The issue lists two divergent files. There were four: `docker-compose.yml` (2025), `SqlServerFixture.cs` (2022), `docs/testcontainers.md` (2022), `README.md` (2022).

## Changes

- `SqlServerFixture` pins `2025-latest` via a public `SqlServerImage` constant
- New `SqlServerVersionConsistencyTests` parses `docker-compose.yml` and fails if it disagrees with the fixture constant. No Docker needed, so it runs in the fast loop and this cannot silently drift again
- `docs/testcontainers.md` updated to match, with rationale and the caveat that production is Azure SQL and matches neither container version

`README.md` left on 2022 deliberately — that is the standalone local SQL Server for development outside the dev container, a genuinely different instance. Changing it is a separate call, not drift.

## Verification

Fast suite green: 174 + 22.

The guard was checked in both directions — passes as committed, and fails with the diff spelled out when `docker-compose.yml` is temporarily set back to 2022.

⚠️ **The container suite has not been run against 2025.** No Docker daemon in the session this was authored in. That run is what actually settles #323:

```bash
dotnet test TimeTracker.Tests --filter "Category=Container"
```

This PR makes the versions agree. It does not prove RLS behaves identically on 2025.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ww9HbTqcsYwwLNqtHyqzoH)_