### PR TITLE
feat: give EF Core tooling its own least-privilege credentials

### DIFF
--- a/.devcontainer/create-app-login.sh
+++ b/.devcontainer/create-app-login.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Creates the low-privilege `timetracker_app` login the running app connects as (mirrors production's
+# timetracker-zak: db_datareader + db_datawriter only). Split into two modes because the database
+# doesn't exist until migrations create it: the server-level login can be created before migrations
+# run, but the database-level user + role grants must wait until after. See ADR-035.
+set -euo pipefail
+
+MODE="${1:?Usage: create-app-login.sh <login|grant>}"
+
+if [ "$MODE" = "login" ]; then
+  docker compose exec -T db /opt/mssql-tools18/bin/sqlcmd \
+    -S localhost -U sa -P "$SA_PASSWORD" -C \
+    -v AppDbPassword="$APP_DB_PASSWORD" \
+    -Q "IF NOT EXISTS (SELECT 1 FROM sys.sql_logins WHERE name = N'timetracker_app') CREATE LOGIN [timetracker_app] WITH PASSWORD = N'\$(AppDbPassword)';"
+elif [ "$MODE" = "grant" ]; then
+  docker compose exec -T db /opt/mssql-tools18/bin/sqlcmd \
+    -S localhost -U sa -P "$SA_PASSWORD" -C -d TimeTrackerDb \
+    -Q "IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = N'timetracker_app') BEGIN CREATE USER [timetracker_app] FOR LOGIN [timetracker_app]; ALTER ROLE db_datareader ADD MEMBER [timetracker_app]; ALTER ROLE db_datawriter ADD MEMBER [timetracker_app]; END"
+else
+  echo "Unknown mode: $MODE" >&2
+  exit 1
+fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,7 @@
       "onAutoForward": "silent"
     }
   },
-  "postCreateCommand": "dotnet tool install --global dotnet-ef && dotnet restore TimeTracker.sln && dotnet ef database update --project TimeTracker.Web --context TimeTrackerDataContext && dotnet ef database update --project TimeTracker.Web --context IdentityDataContext",
+  "postCreateCommand": "dotnet tool install --global dotnet-ef && dotnet restore TimeTracker.sln && bash .devcontainer/create-app-login.sh login && dotnet ef database update --project TimeTracker.Web --context TimeTrackerDataContext && dotnet ef database update --project TimeTracker.Web --context IdentityDataContext && bash .devcontainer/create-app-login.sh grant",
   "postStartCommand": "cd TimeTracker.Web && dotnet run --launch-profile container",
   "customizations": {
     "vscode": {

--- a/.env.example
+++ b/.env.example
@@ -3,11 +3,12 @@
 # Google OAuth credentials and AdminEmail come from .NET User Secrets — no duplication needed here.
 # Only the SQL Server credentials are needed because the container DB is separate from your local one.
 
-# SQL Server SA password
+# SQL Server SA password — admin login used by the container DB itself, and by dotnet ef migrations
+# (docker-compose.yml points MigrationsDbUser/MigrationsDbPassword here)
 # Must be at least 8 characters and contain: uppercase, lowercase, digit, and symbol
 SA_PASSWORD=
 
-# Application database credentials used by the .NET app to connect to the container SQL Server
-# Simplest approach: use SA directly — DB_USER=sa, DB_PASSWORD=<same as SA_PASSWORD>
-DB_USER=
-DB_PASSWORD=
+# Password for the app's low-privilege login (timetracker_app), created automatically by
+# .devcontainer/create-app-login.sh on first container start. db_datareader + db_datawriter only —
+# mirrors production's least-privilege model (see ADR-035). Any local-only value works.
+APP_DB_PASSWORD=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,12 +71,13 @@ jobs:
       - name: Install dotnet-ef
         run: dotnet tool install --global dotnet-ef
 
-      # EF Core's design-time tooling defaults to the Development environment for design-time
-      # operations regardless of what the app would actually run as. That flips
-      # ConnectionStringBuilder.Build's IsDevelopment() check true, which then expects DbUser/
-      # DbPassword config that only exists as local user secrets - not in CI. Forcing Production
-      # keeps design-time operations on the same code path as the real app. Applies to both
-      # steps below, since both invoke dotnet-ef's design-time host building.
+      # dotnet-ef builds contexts via TimeTrackerDataContextFactory/IdentityDataContextFactory
+      # (IDesignTimeDbContextFactory<T> in TimeTracker.Web/Data/, see ADR-035), not by reflecting
+      # into Program.cs. Those factories default to Development-like behaviour (inject
+      # MigrationsDbUser/MigrationsDbPassword via ConnectionStringBuilder) unless
+      # ASPNETCORE_ENVIRONMENT is explicitly "Production" - forcing it here keeps CI on the
+      # Azure AD connection-string path instead of expecting local-only migrations secrets that
+      # don't exist in this environment. Applies to both steps below, since both invoke dotnet-ef.
       #
       # This script is generated purely as a reviewable audit artifact (uploaded below, before
       # the actual apply step) - it is never executed. Applying migrations goes through EF's own

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ docker compose logs db        # SQL Server logs
 ```bash
 PLAYWRIGHT_WRITE_TESTS=true BROWSER= dotnet test TimeTracker.sln --logger "console;verbosity=normal" --blame-hang-timeout 60s
 ```
-Prerequisite: SQL Server running, user secrets set (`DbUser`, `DbPassword`). **Local only — not available in remote sessions.**
+Prerequisite: SQL Server running, user secrets set (`DbUser`/`DbPassword` for the app, `MigrationsDbUser`/`MigrationsDbPassword` for `dotnet ef` — see below). **Local only — not available in remote sessions.**
 
 **During development** (fast feedback, no DB or Docker needed):
 ```bash
@@ -172,10 +172,27 @@ dotnet ef migrations add <MigrationName> --context IdentityDataContext
 dotnet ef database update --context TimeTrackerDataContext
 dotnet ef database update --context IdentityDataContext
 
-# Set user secrets (required for local dev DB credentials)
+# One-time: create the low-privilege login the running app connects as (mirrors production's
+# timetracker-zak — db_datareader + db_datawriter only). Run against your local SQL Server via
+# sqlcmd/SSMS:
+#   IF NOT EXISTS (SELECT 1 FROM sys.sql_logins WHERE name = N'timetracker_app')
+#       CREATE LOGIN [timetracker_app] WITH PASSWORD = N'<local-only-password>';
+#   USE TimeTrackerDb;
+#   IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = N'timetracker_app')
+#   BEGIN
+#       CREATE USER [timetracker_app] FOR LOGIN [timetracker_app];
+#       ALTER ROLE db_datareader ADD MEMBER [timetracker_app];
+#       ALTER ROLE db_datawriter ADD MEMBER [timetracker_app];
+#   END
+
+# Set user secrets — two separate credential pairs (see ADR-035):
+#   DbUser/DbPassword            -> timetracker_app, used by the running app
+#   MigrationsDbUser/MigrationsDbPassword -> sa, used only by dotnet ef (needs DDL rights)
 cd TimeTracker.Web
-dotnet user-secrets set "DbUser" "<username>"
+dotnet user-secrets set "DbUser" "timetracker_app"
 dotnet user-secrets set "DbPassword" "<password>"
+dotnet user-secrets set "MigrationsDbUser" "sa"
+dotnet user-secrets set "MigrationsDbPassword" "<sa-password>"
 ```
 
 The app runs at `https://localhost:7006` (https) or `http://localhost:5019` (http). Swagger UI is available at `/swagger`.
@@ -210,7 +227,7 @@ All WASM pages (`@page` components in `TimeTracker.Wasm`) must carry `@attribute
 
 OAuth challenge links must use `data-enhance-nav="false"` to force a full-page navigation. Without it, Blazor's enhanced navigation turns the click into a fetch, which follows the redirect to `accounts.google.com` and is blocked by the CSP (`connect-src 'self'`).
 
-In development, DB credentials (`DbUser`, `DbPassword`) are injected via [.NET User Secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets) and merged into the connection string at startup.
+In development, DB credentials (`DbUser`, `DbPassword`) are injected via [.NET User Secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets) and merged into the connection string at startup. `dotnet ef` uses a separate, DDL-capable credential pair (`MigrationsDbUser`, `MigrationsDbPassword`) via `IDesignTimeDbContextFactory<T>` implementations in `TimeTracker.Web/Data/`, so the app's own runtime credential never needs schema-modification rights — see ADR-035.
 
 ### Contracts and DTOs
 

--- a/TimeTracker.Tests/Infrastructure/ConnectionStringBuilderTests.cs
+++ b/TimeTracker.Tests/Infrastructure/ConnectionStringBuilderTests.cs
@@ -1,0 +1,70 @@
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
+using TimeTracker.Web.Infrastructure;
+using Xunit;
+
+namespace TimeTracker.Tests.Infrastructure;
+
+public class ConnectionStringBuilderTests
+{
+    private static IConfiguration BuildConfig(params (string Key, string? Value)[] pairs) =>
+        new ConfigurationBuilder().AddInMemoryCollection(
+            pairs.ToDictionary(p => p.Key, p => p.Value)).Build();
+
+    [Fact]
+    public void Build_InjectsCredentials_WhenIsDevelopment()
+    {
+        var configuration = BuildConfig(
+            ("ConnectionStrings:Conn", "Server=localhost;Database=Db"),
+            ("User", "app_user"),
+            ("Password", "app_password"));
+
+        var result = ConnectionStringBuilder.Build(configuration, isDevelopment: true, "Conn", "User", "Password");
+
+        var builder = new SqlConnectionStringBuilder(result);
+        Assert.Equal("app_user", builder.UserID);
+        Assert.Equal("app_password", builder.Password);
+    }
+
+    [Fact]
+    public void Build_DoesNotInjectCredentials_WhenNotDevelopment()
+    {
+        var configuration = BuildConfig(
+            ("ConnectionStrings:Conn", "Server=localhost;Database=Db"),
+            ("User", "app_user"),
+            ("Password", "app_password"));
+
+        var result = ConnectionStringBuilder.Build(configuration, isDevelopment: false, "Conn", "User", "Password");
+
+        var builder = new SqlConnectionStringBuilder(result);
+        Assert.Equal(string.Empty, builder.UserID);
+        Assert.Equal(string.Empty, builder.Password);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Build_AlwaysSetsFreeTierPoolLimits(bool isDevelopment)
+    {
+        var configuration = BuildConfig(
+            ("ConnectionStrings:Conn", "Server=localhost;Database=Db"),
+            ("User", "app_user"),
+            ("Password", "app_password"));
+
+        var result = ConnectionStringBuilder.Build(configuration, isDevelopment, "Conn", "User", "Password");
+
+        var builder = new SqlConnectionStringBuilder(result);
+        Assert.Equal(0, builder.MinPoolSize);
+        Assert.Equal(30, builder.MaxPoolSize);
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("Development", true)]
+    [InlineData("Staging", true)]
+    [InlineData("Production", false)]
+    public void IsDevelopmentEnvironment_DefaultsTrueUnlessExplicitlyProduction(string? aspnetcoreEnvironment, bool expected)
+    {
+        Assert.Equal(expected, ConnectionStringBuilder.IsDevelopmentEnvironment(aspnetcoreEnvironment));
+    }
+}

--- a/TimeTracker.Web/Data/IdentityDataContextFactory.cs
+++ b/TimeTracker.Web/Data/IdentityDataContextFactory.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+using TimeTracker.Web.Infrastructure;
+
+namespace TimeTracker.Web.Data;
+
+// See TimeTrackerDataContextFactory - same rationale (ADR-035).
+public class IdentityDataContextFactory : IDesignTimeDbContextFactory<IdentityDataContext>
+{
+    public IdentityDataContext CreateDbContext(string[] args)
+    {
+        var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Development";
+        var isDevelopment = ConnectionStringBuilder.IsDevelopmentEnvironment(environment);
+
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(AppContext.BaseDirectory)
+            .AddJsonFile("appsettings.json", optional: false)
+            .AddJsonFile($"appsettings.{environment}.json", optional: true)
+            .AddUserSecrets<Program>(optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var connectionString = ConnectionStringBuilder.Build(
+            configuration, isDevelopment, "IdentityConnection", "MigrationsDbUser", "MigrationsDbPassword");
+
+        var optionsBuilder = new DbContextOptionsBuilder<IdentityDataContext>();
+        optionsBuilder.UseSqlServer(connectionString);
+
+        return new IdentityDataContext(optionsBuilder.Options);
+    }
+}

--- a/TimeTracker.Web/Data/TimeTrackerDataContextFactory.cs
+++ b/TimeTracker.Web/Data/TimeTrackerDataContextFactory.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+using TimeTracker.Web.Infrastructure;
+
+namespace TimeTracker.Web.Data;
+
+// dotnet ef prefers this factory over reflecting into Program.cs's host builder, which lets
+// design-time tooling authenticate as MigrationsDbUser/MigrationsDbPassword - a separate,
+// DDL-capable credential from DbUser/DbPassword, which the running app uses instead. See ADR-035.
+public class TimeTrackerDataContextFactory : IDesignTimeDbContextFactory<TimeTrackerDataContext>
+{
+    public TimeTrackerDataContext CreateDbContext(string[] args)
+    {
+        var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Development";
+        var isDevelopment = ConnectionStringBuilder.IsDevelopmentEnvironment(environment);
+
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(AppContext.BaseDirectory)
+            .AddJsonFile("appsettings.json", optional: false)
+            .AddJsonFile($"appsettings.{environment}.json", optional: true)
+            .AddUserSecrets<Program>(optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var connectionString = ConnectionStringBuilder.Build(
+            configuration, isDevelopment, "TimeTrackerConnection", "MigrationsDbUser", "MigrationsDbPassword");
+
+        var optionsBuilder = new DbContextOptionsBuilder<TimeTrackerDataContext>();
+        optionsBuilder.UseSqlServer(connectionString);
+
+        return new TimeTrackerDataContext(optionsBuilder.Options);
+    }
+}

--- a/TimeTracker.Web/Infrastructure/ConnectionStringBuilder.cs
+++ b/TimeTracker.Web/Infrastructure/ConnectionStringBuilder.cs
@@ -1,23 +1,31 @@
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
 
 namespace TimeTracker.Web.Infrastructure;
 
 public static class ConnectionStringBuilder
 {
     // Azure SQL free tier: two pools × 30 = 60 max connections (75 limit), MinPoolSize=0 enables auto-pause.
-    public static string Build(WebApplicationBuilder builder, string connectionCfgName, string userCfgName, string passwordCfgName)
+    public static string Build(IConfiguration configuration, bool isDevelopment, string connectionCfgName, string userCfgName, string passwordCfgName)
     {
-        var connectionString = builder.Configuration.GetConnectionString(connectionCfgName);
+        var connectionString = configuration.GetConnectionString(connectionCfgName);
         var conStrBuilder = new SqlConnectionStringBuilder(connectionString)
         {
             MinPoolSize = 0,
             MaxPoolSize = 30,
         };
-        if (builder.Environment.IsDevelopment())
+        if (isDevelopment)
         {
-            conStrBuilder.UserID = builder.Configuration[userCfgName];
-            conStrBuilder.Password = builder.Configuration[passwordCfgName];
+            conStrBuilder.UserID = configuration[userCfgName];
+            conStrBuilder.Password = configuration[passwordCfgName];
         }
         return conStrBuilder.ConnectionString;
     }
+
+    // EF Core's design-time tooling has no IWebHostEnvironment to consult, so design-time factories
+    // derive it from ASPNETCORE_ENVIRONMENT directly. Defaults to Development-like behavior (inject
+    // credentials) unless explicitly told "Production" - this mirrors EF's own historical default of
+    // treating design-time tooling as Development, which CI deliberately overrides.
+    public static bool IsDevelopmentEnvironment(string? aspnetcoreEnvironment) =>
+        aspnetcoreEnvironment != "Production";
 }

--- a/TimeTracker.Web/Program.cs
+++ b/TimeTracker.Web/Program.cs
@@ -23,8 +23,8 @@ builder.Host.UseSerilog((context, services, config) =>
         .ReadFrom.Services(services)
         .Enrich.FromLogContext());
 
-var timeTrackerConnection = ConnectionStringBuilder.Build(builder, "TimeTrackerConnection", "DbUser", "DbPassword");
-var identityConnection = ConnectionStringBuilder.Build(builder, "IdentityConnection", "DbUser", "DbPassword");
+var timeTrackerConnection = ConnectionStringBuilder.Build(builder.Configuration, builder.Environment.IsDevelopment(), "TimeTrackerConnection", "DbUser", "DbPassword");
+var identityConnection = ConnectionStringBuilder.Build(builder.Configuration, builder.Environment.IsDevelopment(), "IdentityConnection", "DbUser", "DbPassword");
 
 builder.Services.AddMudServices();
 builder.Services.AddRazorComponents().AddInteractiveWebAssemblyComponents();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,10 @@ services:
       ASPNETCORE_URLS: http://+:5019
       ConnectionStrings__TimeTrackerConnection: "Server=db,1433;Database=TimeTrackerDb;TrustServerCertificate=True"
       ConnectionStrings__IdentityConnection: "Server=db,1433;Database=TimeTrackerDb;TrustServerCertificate=True"
-      DbUser: "${DB_USER}"
-      DbPassword: "${DB_PASSWORD}"
+      DbUser: "timetracker_app"
+      DbPassword: "${APP_DB_PASSWORD}"
+      MigrationsDbUser: "sa"
+      MigrationsDbPassword: "${SA_PASSWORD}"
     ports:
       - "5019:5019"
     volumes:

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -40,6 +40,7 @@ Architectural decisions that were non-obvious, had meaningful alternatives, or a
 | [ADR-032](#adr-032-oidc-over-publish-profile-for-github-actions--azure-deploy-auth) | OIDC over publish-profile for GitHub Actions → Azure deploy auth | 2026-06 | Accepted |
 | [ADR-033](#adr-033-named-rls_bypass-role-over-blanket-db_owner-rls-exemption) | Named `rls_bypass` role over blanket `db_owner` RLS exemption | 2026-07 | Accepted |
 | [ADR-034](#adr-034-securitystamp-session-revocation-over-a-redis-backed-revocation-list) | `SecurityStamp` session revocation over a Redis-backed revocation list | 2026-06 | Accepted |
+| [ADR-035](#adr-035-idesigntimedbcontextfactory-for-a-least-privilege-local-app-login) | `IDesignTimeDbContextFactory` for a least-privilege local app login | 2026-08 | Accepted |
 
 ---
 
@@ -918,3 +919,32 @@ Rolled out as two migrations rather than one: `AddRlsBypassRole` creates the rol
 - ✅ Admin-only `revoke-sessions` endpoint gives a real "log out everywhere" capability without ending the admin's own session
 - ❌ Revocation is only checked every 30 minutes (the validation interval), not on every single request — a revoked cookie can still be used for up to that window. Acceptable trade-off for a personal app; a tighter interval increases DB round-trips per request
 - ❌ This approach does not generalise past a single logical database — if the app ever needed multi-region or cross-database session state, a shared store (Redis or similar) would become necessary again
+
+---
+
+## ADR-035: `IDesignTimeDbContextFactory` for a least-privilege local app login
+
+**Date:** 2026-08 — **Status:** Accepted — **Closes:** [#324](https://github.com/zkarachiwala/TimeTracker/issues/324)
+
+**Context:** The app and `dotnet ef` shared one connection string and one set of credentials (`DbUser`/`DbPassword`) — locally, `sa`. `dotnet ef` needs DDL rights to create and apply migrations, so the app's own runtime credential had to be privileged enough to satisfy that, with no mechanism to narrow it without also breaking migrations. This is the same problem [ADR-031](#adr-031-pipeline-migrations--least-privilege-app-identity-supersedes-adr-022) already solved for production, where the app's Managed Identity held `CREATE FUNCTION`/`ALTER ANY SECURITY POLICY` purely so it could self-migrate on startup — a compromised app tier could disable its own RLS policies. Locally, `sa` running the app meant every RLS/least-privilege guarantee documented in `docs/rls-security-model.md` for production had no local equivalent to actually exercise.
+
+`dotnet ef` prefers an `IDesignTimeDbContextFactory<T>` over reflecting into `Program.cs`'s host builder when one exists — the standard EF Core mechanism for giving tooling its own connection without the app ever holding those rights.
+
+**Decision:** Add `TimeTrackerDataContextFactory` and `IdentityDataContextFactory` (`TimeTracker.Web/Data/`), each an `IDesignTimeDbContextFactory<T>` that builds its own configuration (`appsettings.json` → `appsettings.{env}.json` → user secrets → environment variables) and resolves connection strings via a new `MigrationsDbUser`/`MigrationsDbPassword` credential pair — separate from the app's own `DbUser`/`DbPassword`. `ConnectionStringBuilder.Build` was refactored to take `IConfiguration`/`bool isDevelopment` instead of `WebApplicationBuilder` so both `Program.cs` and the new factories share the same pooling/credential-injection logic. A new low-privilege `timetracker_app` login (`db_datareader`+`db_datawriter` only, mirroring production's `timetracker-zak`) is what the app now connects as, both in WSL2 (documented manual one-time SQL step) and the dev container (automated via `.devcontainer/create-app-login.sh` in `postCreateCommand`). `sa` remains the migrations-only credential in both environments and deliberately does **not** join `rls_bypass` — `docs/rls-security-model.md` already states local dev should enforce RLS exactly like production, and there are no data-touching migrations today for the backfill gap [ADR-031](#adr-031-pipeline-migrations--least-privilege-app-identity-supersedes-adr-022) flagged for the production migrations principal to actually apply.
+
+**The environment-detection detail that made this non-trivial:** CI's `deploy.yml` `migrate` job already had to fight EF's design-time defaults — it sets `ASPNETCORE_ENVIRONMENT: Production` explicitly, because EF's tooling otherwise defaults design-time host-building to "Development" (which would flip `ConnectionStringBuilder`'s dev check true and expect local-only secrets that don't exist in CI). Replacing reflection-based host building with explicit factories means that implicit EF default no longer applies automatically — the factories replicate it themselves via `ConnectionStringBuilder.IsDevelopmentEnvironment`, defaulting to Development-like behaviour unless `ASPNETCORE_ENVIRONMENT` is explicitly `"Production"`. Getting this backwards would silently break local `dotnet ef` (can't authenticate) in a way that looks like a SQL config problem rather than a logic bug — covered by a unit test. A second, smaller CI-compatibility fix: the factories resolve config from `AppContext.BaseDirectory` (the build output directory, where `appsettings*.json` are already copied) rather than `Directory.GetCurrentDirectory()`, since CI invokes `dotnet-ef --project TimeTracker.Web/TimeTracker.Web.csproj` from the repo root, not from inside `TimeTracker.Web/`.
+
+**Options considered:**
+
+| Option | Why rejected / accepted |
+|--------|-------------------------|
+| **`IDesignTimeDbContextFactory<T>` + separate `MigrationsDbUser`/`MigrationsDbPassword`** | Accepted — the standard, documented EF Core mechanism for giving tooling its own connection; requires no changes to how the app itself resolves its connection at runtime |
+| Keep one shared credential, narrow it as far as both the app and migrations can tolerate | Rejected — DDL rights (`db_ddladmin` or `db_owner`) are strictly broader than the app ever needs (`db_datareader`+`db_datawriter`); any shared credential is only as narrow as the more privileged consumer requires |
+| Give `sa` `rls_bypass` locally, for symmetry with the production migrations principal | Rejected — no data-touching (backfill) migrations exist today, so the gap this would close doesn't currently apply; granting it pre-emptively would quietly reopen the bypass [ADR-033](#adr-033-named-rls_bypass-role-over-blanket-db_owner-rls-exemption) closed, for no present benefit |
+
+**Consequences:**
+- ✅ The local running app can finally hold the same minimal grant set as production (`db_datareader`+`db_datawriter` only) — local dev now exercises the same least-privilege guarantees `docs/rls-security-model.md` documents for production, instead of running everything as `sa`
+- ✅ `dotnet ef` keeps the DDL rights it needs (`sa`) without the app ever holding them
+- ✅ Both WSL2 (primary) and the dev container (secondary) get the same credential split, via a manual documented step and an automated bootstrap script respectively
+- ❌ Two credential pairs to manage locally instead of one (`DbUser`/`DbPassword` and `MigrationsDbUser`/`MigrationsDbPassword`) — mirrors the production split already established by ADR-031, so not a new pattern, just a second place it now applies
+- ❌ The dev container's login-creation script depends on `docker compose` being callable from inside the `app` container via the `docker-outside-of-docker` feature, and on the exact `mssql-tools18` path in the `db` image — both verified against the current image but a future base-image bump could shift either

--- a/docs/plans/issue-324-migrations-credential-split.md
+++ b/docs/plans/issue-324-migrations-credential-split.md
@@ -1,0 +1,91 @@
+# EF design-time credential split rollout — issue #324
+
+Companion to `docs/plans/migrations-principal-rollout.md` and `docs/plans/rls-bypass-rollout.md`. Those
+rollouts narrowed the *production* app identity and replaced a blanket RLS exemption; this one does the
+local-development equivalent — giving `dotnet ef` its own credential so the locally-running app can
+finally hold the same minimal grant set as production (`db_datareader`+`db_datawriter` only, mirroring
+`timetracker-zak`) instead of running as `sa`. See `docs/decisions.md` ADR-035 for the full rationale.
+
+Ordered so there is no point where either `dotnet ef` or the running app is broken.
+
+## 1. Code changes (this PR)
+
+- [x] `ConnectionStringBuilder.Build` refactored to take `IConfiguration`/`bool isDevelopment` instead of `WebApplicationBuilder`; `IsDevelopmentEnvironment` helper added.
+- [x] `Program.cs` call sites updated.
+- [x] `TimeTrackerDataContextFactory` / `IdentityDataContextFactory` added (`TimeTracker.Web/Data/`), reading `MigrationsDbUser`/`MigrationsDbPassword`.
+- [x] `ConnectionStringBuilderTests` added.
+- [x] Dev container: `.devcontainer/create-app-login.sh`, `devcontainer.json` `postCreateCommand`, `docker-compose.yml` `app`/`db` env, `.env.example` updated.
+- [x] Docs: `CLAUDE.md`, `docs/rls-security-model.md`, `.github/workflows/deploy.yml` comment, ADR-035.
+
+At this stage, in every environment, `MigrationsDbUser`/`MigrationsDbPassword` point at the **same**
+login the app's `DbUser`/`DbPassword` already use (`sa` locally) — same credential, new secret names,
+no functional change yet. This isolates "does the factory wiring work" from "does narrowing the app's
+own credential work," so a problem in either step is easy to attribute.
+
+## 2. Verify the factories work, still against `sa`
+
+From `TimeTracker.Web/`:
+```bash
+dotnet user-secrets set "MigrationsDbUser" "sa"
+dotnet user-secrets set "MigrationsDbPassword" "<your local sa password>"
+
+dotnet ef migrations add SanityCheck --context TimeTrackerDataContext
+dotnet ef migrations remove --context TimeTrackerDataContext
+```
+Confirms the design-time factory builds and connects correctly before the credential-narrowing step.
+
+From the **repo root** (mirrors CI's actual invocation — `--project` does not change the process's
+working directory, which is what tripped up the original config-loading approach):
+```bash
+dotnet ef migrations script --idempotent --context TimeTrackerDataContext --project TimeTracker.Web/TimeTracker.Web.csproj --output /tmp/test.sql
+dotnet ef migrations script --idempotent --context IdentityDataContext --project TimeTracker.Web/TimeTracker.Web.csproj --output /tmp/test-identity.sql
+```
+
+- [ ] Both commands complete without error, locally.
+
+## 3. Create the `timetracker_app` login (WSL2)
+
+Run once against your local SQL Server (`sqlcmd`/SSMS) — see `CLAUDE.md`'s migration-commands section
+for the exact idempotent SQL. Server-level `CREATE LOGIN` first; the database-level `CREATE USER` +
+role grants can run in the same session since `TimeTrackerDb` already exists on an established local
+instance (unlike a fresh dev-container volume, where the two steps must be split around migrations —
+see `.devcontainer/create-app-login.sh`).
+
+- [ ] `timetracker_app` login created, `db_datareader`+`db_datawriter` granted on `TimeTrackerDb`.
+
+## 4. Repoint the app's own credential (WSL2)
+
+```bash
+dotnet user-secrets set "DbUser" "timetracker_app"
+dotnet user-secrets set "DbPassword" "<the password you set above>"
+```
+Restart `dotnet run`; exercise basic CRUD (create a time entry, list projects) — confirms
+`db_datareader`+`db_datawriter` is sufficient at runtime and RLS still isolates per-user data exactly
+as it does for `timetracker-zak` in production.
+
+- [ ] App boots and basic CRUD works as `timetracker_app`.
+
+## 5. Confirm migrations still work once the app is narrowed
+
+```bash
+cd TimeTracker.Web
+dotnet ef migrations add TrivialCheck --context TimeTrackerDataContext
+dotnet ef migrations remove --context TimeTrackerDataContext
+```
+This is the actual regression the whole change prevents: `MigrationsDbUser` (`sa`) must keep working
+for schema changes after `DbUser` no longer can.
+
+- [ ] Confirmed.
+
+## 6. Dev container (best-effort)
+
+Rebuild the container and confirm `postCreateCommand` completes: login creation → both
+`dotnet ef database update` calls → grant step. Given the known, unrelated SSMS/firewall connectivity
+issue with this environment, full end-to-end verification here isn't a hard requirement for this
+issue — the goal is confirming the bootstrap script itself runs cleanly.
+
+- [ ] `postCreateCommand` completes without error on a fresh rebuild.
+
+## 7. Done
+
+- [ ] All of the above checked off, `dotnet test TimeTracker.Tests && dotnet test TimeTracker.ComponentTests` green, PR raised.

--- a/docs/rls-security-model.md
+++ b/docs/rls-security-model.md
@@ -110,7 +110,8 @@ Two consequences worth internalising:
 
 | Principal | Used by | RLS applies? |
 |---|---|---|
-| `sa` / `db_owner` | Local dev, SSMS | **Yes** — no longer exempt |
+| `timetracker_app` (`db_datareader` + `db_datawriter`) | Local dev app runtime (ADR-035) | **Yes** |
+| `sa` / `db_owner` | Local `dotnet ef` migrations only (ADR-035); ad hoc SSMS queries | **Yes** — no longer exempt |
 | Managed Identity (`db_datareader` + `db_datawriter`) | Production app | **Yes** |
 | Backup SP (`db_ddladmin` + `db_datareader` + `rls_bypass`) | Nightly `.bacpac` export | No — needs full rows to export |
 | Migrations SP `timetracker-github-migrations` (`db_datareader` + `db_datawriter` + `db_ddladmin` + `ALTER ANY SECURITY POLICY` + `rls_bypass`) | Pipeline migrations (ADR-031) | No — a `FILTER` predicate applies to `UPDATE` too; without the bypass a future backfill would touch zero rows and report success |


### PR DESCRIPTION
## Summary
- Adds `IDesignTimeDbContextFactory<T>` for both `TimeTrackerDataContext` and `IdentityDataContext` (`TimeTracker.Web/Data/`), so `dotnet ef` authenticates via new `MigrationsDbUser`/`MigrationsDbPassword` credentials instead of sharing the app's own `DbUser`/`DbPassword`
- Refactors `ConnectionStringBuilder.Build` to take `IConfiguration`/`bool isDevelopment` instead of `WebApplicationBuilder`, so both `Program.cs` and the new factories share the same pooling/credential-injection logic; adds `IsDevelopmentEnvironment` helper
- Introduces a new low-privilege `timetracker_app` login (`db_datareader`+`db_datawriter` only, mirroring production's `timetracker-zak`) that the running app connects as — closing the last local gap left by ADR-031/ADR-033's least-privilege work
- Wires the credential split into both environments: a documented manual SQL step for the primary WSL2 setup (`CLAUDE.md`), and automated bootstrap via `.devcontainer/create-app-login.sh` in `postCreateCommand` for the dev container
- Updates `.github/workflows/deploy.yml`'s `migrate` job comment to describe the new factory-based mechanism (the `ASPNETCORE_ENVIRONMENT: Production` env vars themselves are unchanged — still required so CI doesn't try to inject local-only migrations secrets)
- Adds ADR-035 (`docs/decisions.md`) and a rollout checklist (`docs/plans/issue-324-migrations-credential-split.md`)
- Updates `docs/rls-security-model.md`'s principal table with the new `timetracker_app` row

## Test plan
- [x] `dotnet test TimeTracker.Tests --filter "Category!=Container"` — 181/181 passing, including new `ConnectionStringBuilderTests`
- [x] `dotnet test TimeTracker.ComponentTests` — 22/22 passing
- [x] Verified the new `TimeTrackerDataContextFactory` against a real local SQL Server via `dotnet ef migrations add`
- [x] Verified `dotnet ef migrations script` succeeds from the **repo root** (mirrors CI's exact invocation), confirming the `AppContext.BaseDirectory` fix resolves config correctly regardless of working directory
- [ ] Manual: create the `timetracker_app` login locally (SQL in `CLAUDE.md`/rollout doc) and repoint `DbUser`/`DbPassword`, confirm app CRUD still works
- [ ] Manual: rebuild dev container, confirm `postCreateCommand` completes end-to-end

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)