### PR TITLE
Loosen SDK rollForward to latestFeature

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "10.0.109",
-    "rollForward": "latestPatch"
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Summary
- Changes `global.json`'s `rollForward` from `latestPatch` to `latestFeature`

## Why
Ubuntu's `dotnet-sdk-10.0` apt package is pinned to the `.1xx` feature band by Canonical policy ([dotnet/core#9258](https://github.com/dotnet/core/discussions/9258)) and will not carry newer feature bands (2xx, 3xx, ...). Microsoft's own apt feed (`packages.microsoft.com`) has no SDK candidate for this Ubuntu release either — confirmed empirically in a remote session (`apt-cache policy dotnet-sdk-10.0` shows only Canonical's archive as a source).

`latestPatch` requires the resolved SDK to match the pinned version's exact feature band, so any future SDK bump that crosses a feature band (like #328) would break `dotnet restore`/`build` in every remote session, since apt has nothing to satisfy it. `latestFeature` keeps the same version floor (`10.0.109`) but accepts any installed feature band at or above it, so remote sessions keep working regardless of which band apt happens to ship.

Verified locally: `dotnet --version` still resolves to `10.0.110`, `dotnet restore --locked-mode` succeeds, solution builds with 0 warnings/errors, and `TimeTracker.Tests` (173 tests, `Category!=Container`) all pass.

## Test plan
- [x] `dotnet restore TimeTracker.sln --locked-mode`
- [x] `dotnet build TimeTracker.sln --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test TimeTracker.Tests --filter "Category!=Container"` — 173/173 passing


---
_Generated by [Claude Code](https://claude.ai/code/session_01266juWqCwahdALwWGQUV45)_