### PR TITLE
Only regenerate Dependabot lock files when locked-mode restore actually fails

### DIFF
--- a/.github/workflows/dependabot-lockfile-fix.yml
+++ b/.github/workflows/dependabot-lockfile-fix.yml
@@ -23,10 +23,33 @@ jobs:
         with:
           global-json-file: global.json
 
+      # Only the lock file of the project Dependabot directly edited is guaranteed
+      # consistent; a locked-mode restore is how we detect whether the transitive
+      # ProjectReference cascade bug (dependabot/dependabot-core#13950) actually
+      # affected this PR, instead of unconditionally regenerating every PR's lock
+      # files with --force-evaluate, which churns unrelated transitive versions too.
+      - name: Check if lock files are already consistent
+        id: check
+        run: dotnet restore TimeTracker.sln --locked-mode
+        continue-on-error: true
+
       - name: Regenerate lock files
+        if: steps.check.outcome == 'failure'
         run: dotnet restore TimeTracker.sln --force-evaluate
 
-      - name: Commit and push if lock files changed
+      # Verified in this same run (not a follow-up triggered run) because a push made
+      # here with GITHUB_TOKEN is treated as bot-authored, and any workflow run that
+      # push triggers afterward is held for manual approval in the Actions UI.
+      - name: Build (verify the regenerated lock files)
+        if: steps.check.outcome == 'failure'
+        run: dotnet build TimeTracker.sln --no-restore --configuration Release
+
+      - name: Test (verify the regenerated lock files)
+        if: steps.check.outcome == 'failure'
+        run: dotnet test TimeTracker.Tests/TimeTracker.Tests.csproj --no-build --configuration Release --logger "console;verbosity=normal"
+
+      - name: Commit and push regenerated lock files
+        if: steps.check.outcome == 'failure'
         run: |
           if git diff --quiet -- '**/packages.lock.json'; then
             echo "Lock files already consistent - nothing to do."


### PR DESCRIPTION
## Summary
- `dependabot-lockfile-fix.yml` now tries `dotnet restore --locked-mode` first, and only regenerates lock files (`--force-evaluate`) and commits when that actually fails
- Build and test now run in the same job that pushes the fix, instead of relying on a follow-up triggered run

## Why
The previous version ran `--force-evaluate` unconditionally on every Dependabot PR, regardless of whether the lock file was actually broken. This churns transitive package versions even when nothing needs fixing — confirmed this round: it pushed "fix" commits on PRs (#348, #349) whose CI had *already passed cleanly* before the fix ran.

Every commit this workflow pushes triggers a follow-up `pull_request: synchronize` event. Because that push is made via `GITHUB_TOKEN` (actor `github-actions[bot]`), GitHub holds the resulting CI/CodeQL runs behind a manual "Approve and run" gate in the Actions UI — they don't execute automatically. So instead of only needing attention for the rare case the workflow was built for (the `ProjectReference` lock cascade bug, [dependabot/dependabot-core#13950](https://github.com/dependabot/dependabot-core/issues/13950)), nearly every Dependabot PR ended up needing a manual approval click, because the workflow was regenerating lock files whether or not the bug was actually present.

This PR narrows the workflow to only act when a locked-mode restore genuinely fails — i.e. only for the PRs the cascade bug actually affects — and verifies the regenerated lock files with a build + test in the same run, so there's no second triggered run left to get stuck behind approval.

## Test plan
- [x] `dotnet restore TimeTracker.sln --locked-mode` — succeeds (no drift on current main)
- [x] `dotnet build TimeTracker.sln --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test TimeTracker.Tests --filter "Category!=Container"` — 173/173 passing (Container tests need Docker, unavailable in this sandbox but present on GitHub's runners, same as `ci.yml` already assumes)
- [x] Workflow YAML validated


---
_Generated by [Claude Code](https://claude.ai/code/session_01266juWqCwahdALwWGQUV45)_