### PR TITLE
Exclude Identity.EntityFrameworkCore from aspnetcore-runtime group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,11 +32,19 @@ updates:
           - "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore"
       # The rest of the ASP.NET Core packages ship together in .NET's monthly patch
       # releases (e.g. 10.0.9 -> 10.0.10 across Web, Client and ComponentTests on the
-      # same day). Grouping avoids 4-6 near-identical separate PRs each month. Listed
-      # after entity-framework-core so those packages keep going to that group instead.
+      # same day). Grouping avoids 4-6 near-identical separate PRs each month.
+      #
+      # exclude-patterns is required, not just listing entity-framework-core first:
+      # in practice Dependabot has proposed Microsoft.AspNetCore.Identity.EntityFrameworkCore
+      # in *both* group PRs in the same run (see #356 vs #357), which breaks the
+      # aspnetcore-runtime PR with a NU1605 downgrade error since it bumps that one
+      # EF-Core-coupled package without its lock-step siblings. The explicit exclude
+      # guarantees this package can only ever go to entity-framework-core.
       aspnetcore-runtime:
         patterns:
           - "Microsoft.AspNetCore.*"
+        exclude-patterns:
+          - "Microsoft.AspNetCore.Identity.EntityFrameworkCore"
     ignore:
       # Microsoft.AspNetCore.OpenApi 10.0.9 pins Microsoft.OpenApi >= 2.0.0 and has not
       # been updated for the 3.x line yet (upstream release notes: 3.x support lands in


### PR DESCRIPTION
## Summary
- Adds `exclude-patterns` to the `aspnetcore-runtime` Dependabot group, explicitly excluding `Microsoft.AspNetCore.Identity.EntityFrameworkCore`

## Why
`dependabot.yml` lists `entity-framework-core` before `aspnetcore-runtime` specifically so `Microsoft.AspNetCore.Identity.EntityFrameworkCore` (which matches both groups' patterns) always groups with its EF Core siblings. Listing order is supposed to be first-match-wins per Dependabot's docs, but this week it proposed the same package in **both** group PRs simultaneously:

- #356 (`entity-framework-core`, 6 packages) — bumps it correctly, alongside `Microsoft.EntityFrameworkCore`, `Microsoft.EntityFrameworkCore.SqlServer`, etc.
- #357 (`aspnetcore-runtime`, 8 packages) — bumps it *alone*, without its EF Core siblings

#357 fails with a real `NU1605`: `Microsoft.AspNetCore.Identity.EntityFrameworkCore 10.0.11` requires `Microsoft.EntityFrameworkCore >= 10.0.11`, but `TimeTracker.Web` still pins `10.0.10` in that PR's branch. This isn't a lock-file drift issue our auto-fix workflow can resolve — it needs the actual version bump that only exists in the other group's PR.

`exclude-patterns` makes the exclusivity explicit and enforced, rather than relying on group-listing order.

## Test plan
- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`
- [x] Parsed structure confirms `exclude-patterns` sits under the `aspnetcore-runtime` group correctly
- Not a code change — no build/test impact. Effect will be observed on the next Dependabot run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01266juWqCwahdALwWGQUV45)_