### PR TITLE
Catch up Dependabot bumps closed as stale, fix SSH.NET vulnerability

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -80,7 +80,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.37.6
+      uses: github/codeql-action/init@v4.37.7
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -109,6 +109,6 @@ jobs:
       run: dotnet build --configuration Release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.37.6
+      uses: github/codeql-action/analyze@v4.37.7
       with:
         category: "/language:${{matrix.language}}"

--- a/TimeTracker.Client/TimeTracker.Client.csproj
+++ b/TimeTracker.Client/TimeTracker.Client.csproj
@@ -6,8 +6,8 @@
     <RootNamespace>TimeTracker.Client</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
     <PackageReference Include="MudBlazor" Version="9.8.0" />
     <PackageReference Include="Heron.MudCalendar" Version="4.0.1" />
     <PackageReference Include="Heron.MudTotalCalendar" Version="4.0.0" />

--- a/TimeTracker.ComponentTests/TimeTracker.ComponentTests.csproj
+++ b/TimeTracker.ComponentTests/TimeTracker.ComponentTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="bunit" Version="2.9.0" />
     <PackageReference Include="AngleSharp" Version="1.7.1" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/TimeTracker.Playwright/TimeTracker.Playwright.csproj
+++ b/TimeTracker.Playwright/TimeTracker.Playwright.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="Microsoft.Playwright.Xunit" Version="1.62.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/TimeTracker.Tests/TimeTracker.Tests.csproj
+++ b/TimeTracker.Tests/TimeTracker.Tests.csproj
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.11" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="Testcontainers.MsSql" Version="4.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.14.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/TimeTracker.Web/TimeTracker.Web.csproj
+++ b/TimeTracker.Web/TimeTracker.Web.csproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.11.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.11" />
     <PackageReference Include="MudBlazor" Version="9.8.0" />
     <PackageReference Include="PublicHoliday" Version="3.14.0" />


### PR DESCRIPTION
## Summary
- Applies the version bumps from #354, #357, #358, #359, #362 directly, since those PRs were closed unmerged (stale against `main` after lock-file removal, not because the updates were unwanted)
- Fixes a high-severity SSH.NET vulnerability (GHSA-q939-rpr3-3284 / CVE-2026-48798) by bumping `Testcontainers.MsSql`

## Changes
- `Microsoft.AspNetCore.*` (Web, Client): 10.0.10 → 10.0.11
- `Microsoft.OpenApi`: 2.11.0 → 2.12.0
- `Microsoft.NET.Test.Sdk` (Tests, ComponentTests, Playwright): 18.8.1 → 18.9.0
- `github/codeql-action`: 4.37.6 → 4.37.7
- `Testcontainers.MsSql`: 4.13.0 → 4.14.0 — pulls in a patched SSH.NET (≥ 2026.0.0), no direct override needed

## Why the SSH.NET vulnerability
`dotnet list package --vulnerable --include-transitive` flagged SSH.NET 2025.1.0 as a transitive dependency of `TimeTracker.Tests` via `Testcontainers.MsSql`. Bumping `Testcontainers.MsSql` to the latest available version (4.14.0) resolves it without needing a direct `PackageReference` override.

## Test plan
- [x] `dotnet restore TimeTracker.sln` — clean, no NU1903 warning
- [x] `dotnet list package --vulnerable --include-transitive` — no vulnerable packages found
- [x] `dotnet build TimeTracker.sln --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test TimeTracker.Tests --filter "Category!=Container"` — 173/173 passing
- [x] `dotnet test TimeTracker.ComponentTests` — 22/22 passing


---
_Generated by [Claude Code](https://claude.ai/code/session_01266juWqCwahdALwWGQUV45)_