### PR TITLE
Fail CI when vulnerable packages are detected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,4 +54,10 @@ jobs:
 
       - name: Check for vulnerable packages
         if: steps.changes.outputs.code == 'true'
-        run: dotnet list package --vulnerable --include-transitive
+        run: |
+          output=$(dotnet list package --vulnerable --include-transitive 2>&1)
+          echo "$output"
+          if echo "$output" | grep -q "has the following vulnerable packages"; then
+            echo "::error::Vulnerable packages detected - see output above."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- `ci.yml`'s "Check for vulnerable packages" step now fails the build when `dotnet list package --vulnerable` finds something, instead of just printing a warning

## Why
`dotnet list package --vulnerable` exits 0 even when it finds a vulnerable package — it's informational only by default. This step has been running on every CI build all along, but because it never failed anything, a real high-severity vulnerability (SSH.NET, GHSA-q939-rpr3-3284) sat in `TimeTracker.Tests`'s dependency tree undetected — the warning was there in the output, but a green checkmark hid it from view.

Now the step captures the command's output and checks for the exact phrase `dotnet list package` prints when a project has vulnerable packages (`"has the following vulnerable packages"`), failing the build with an annotated `::error::` if found.

## Test plan
- [x] Ran locally against current clean `main` state — passes
- [x] Temporarily reintroduced the old vulnerable `Testcontainers.MsSql` 4.13.0 (which pulls in the vulnerable SSH.NET) and re-ran the exact check logic — correctly detects and would fail
- [x] Reverted the temporary change, confirmed clean state restored
- [x] `dotnet build TimeTracker.sln --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test TimeTracker.Tests --filter "Category!=Container"` — 173/173 passing


---
_Generated by [Claude Code](https://claude.ai/code/session_01266juWqCwahdALwWGQUV45)_