### PR TITLE
Bump xunit.runner.visualstudio 3.1.5 -> 4.0.0

### DIFF
--- a/TimeTracker.ComponentTests/TimeTracker.ComponentTests.csproj
+++ b/TimeTracker.ComponentTests/TimeTracker.ComponentTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="bunit" Version="2.9.0" />
     <PackageReference Include="AngleSharp" Version="1.7.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TimeTracker.Playwright/TimeTracker.Playwright.csproj
+++ b/TimeTracker.Playwright/TimeTracker.Playwright.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="Microsoft.Playwright.Xunit" Version="1.62.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TimeTracker.Tests/TimeTracker.Tests.csproj
+++ b/TimeTracker.Tests/TimeTracker.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.14.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
- Bumps `xunit.runner.visualstudio` from 3.1.5 to 4.0.0 across `TimeTracker.Tests`, `TimeTracker.ComponentTests`, and `TimeTracker.Playwright`

## Why / breaking-change check
Dependabot proposed this in #366, but that PR was closed — it still carried a `packages.lock.json` diff computed before the lock-file removal (#363), same modify/delete conflict pattern as #354.

Checked upstream release notes before reapplying, since this is a major version bump: [xunit.net/releases/visualstudio/4.0.0](https://xunit.net/releases/visualstudio/4.0.0) lists only two changes — added support for xUnit v3 4.0 test projects (additive, doesn't affect our `xunit` 2.9.3 packages) and a bug fix for message ordering during shutdown. No breaking changes, removals, or minimum-version bumps documented.

## Test plan
- [x] `dotnet restore TimeTracker.sln` — clean
- [x] `dotnet build TimeTracker.sln --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test TimeTracker.Tests --filter "Category!=Container"` — 173/173 passing
- [x] `dotnet test TimeTracker.ComponentTests` — 22/22 passing


---
_Generated by [Claude Code](https://claude.ai/code/session_01266juWqCwahdALwWGQUV45)_